### PR TITLE
fix: Ensure future-dated content is built by Hugo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build.environment]
+  HUGO_VERSION = "0.148.2"
   YARN_VERSION = "1.12.1"
   NPM_VERSION = "6.4.1"
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:hugo",
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
-    "build:hugo": "hugo -d ../dist -s site -v",
+    "build:hugo": "hugo -d ../dist -s site -v -F",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
     "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
     "postbuild": "node algolia-indexer.js"


### PR DESCRIPTION
This PR modifies the Hugo build command in package.json to include the -F flag, ensuring that content with future dates (like the classes page) is correctly built and published on Netlify.