### PR TITLE
Update translate page with apostille guidance

### DIFF
--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -56,7 +56,7 @@ Start your Italian journey with our friendly, hands-on beginner class! In 5 mont
 
 **New session starting in April!** We just added a new Tuesday beginner section:
 
-<div class="tc"><a href='{{< relref "news/new-tuesday-beginner-5-30pm-march-may-2026.md" >}}' class="btn raise">New Tuesday In-person Beginner (April–May)</a></div>
+<div class="tc"><a href='{{< relref "news/new-tuesday-beginner-italian-class-march-may-2026.md" >}}' class="btn raise">New Tuesday In-person Beginner (April–May)</a></div>
 
 
 

--- a/site/content/translate.md
+++ b/site/content/translate.md
@@ -40,7 +40,7 @@ We provide a certificate of accurate translation signed by our school director, 
 
 ## Apostilles
 
-An Apostille authenticates public officials' signatures on documents to be used outside the United States of America. We do not issue apostilles, but we can translate them.
+An Apostille authenticates public officials' signatures on documents to be used outside the United States of America. We do not issue apostilles, but we can translate them. Note that we have received guidance from the Italian Consulate in Los Angeles that apostilles do not need to be translated and can be submitted in English.
 
 If you need an apostille, it can be [requested from the California Secretary of State](https://www.sos.ca.gov/notary/request-apostille) by mail through their Sacramento office or in person at their Sacramento and Los Angeles offices.
 


### PR DESCRIPTION
Added a note to the apostilles section on the translate page specifying that the Italian Consulate in Los Angeles advises that apostilles do not need to be translated and can be submitted in English.

---
*PR created automatically by Jules for task [16823782810537085430](https://jules.google.com/task/16823782810537085430) started by @zonca*