### PR TITLE
feat: Add youtube links page

### DIFF
--- a/site/content/show/ifl-play-2026-music-links.md
+++ b/site/content/show/ifl-play-2026-music-links.md
@@ -1,5 +1,5 @@
 ---
-title: "YouTube Links"
+title: "IFL play 2026 music links"
 date: 2024-05-01
 ---
 

--- a/site/content/show/youtube-links.md
+++ b/site/content/show/youtube-links.md
@@ -1,0 +1,17 @@
+---
+title: "YouTube Links"
+date: 2024-05-01
+---
+
+The following is a list of YouTube links from the document, organized by the scene they appear in:
+
+1.  **APERTURA MUSICALE** (Canzoncina del buongiorno dei piccoli): [Link](https://www.youtube.com/watch?v=0Jlamf8cPW8&list=RD0Jlamf8cPW8&start_radio=1)
+2.  **SCENA 4 – ROMA** ("Roma Capoccia" di Antonello Venditti): [Link](https://www.youtube.com/watch?v=YZLnGNrsCYg&utm_source=chatgpt.com)
+3.  **SCENA 5 – FIRENZE** ("Firenze sogna" di Claudio Villa): [Link](https://www.youtube.com/watch?v=z-8b3AmBnbQ&list=RDz-8b3AmBnbQ&start_radio=1)
+4.  **SCENA 6 – VENEZIA** (Pre-scene song, first mention): [Link](https://www.youtube.com/watch?v=D5T-RxcabNY&list=RDD5T-RxcabNY&start_radio=1)
+5.  **SCENA 6 – VENEZIA** (Pre-scene song, second mention): [Link](https://www.youtube.com/watch?v=Rf9FJqX_qYE&list=RDRf9FJqX_qYE&start_radio=1)
+6.  **SCENA 7 – MILANO** ("Milano" di Lucio Dalla): [Link](https://www.youtube.com/watch?v=iTrMfJ39VS4&list=RDiTrMfJ39VS4&start_radio=1)
+7.  **SCENA 8 – NAPOLI** (Pre-scene song): [Link](https://www.youtube.com/watch?v=hWtL6nfV5HM&list=RDhWtL6nfV5HM&start_radio=1)
+8.  **SCENA 9 – LE ISOLE** (Pre-scene song): [Link](https://www.youtube.com/watch?v=3nxoYO6dsiY&list=RD3nxoYO6dsiY&start_radio=1)
+9.  **SCENA 10 – L’ITALIA FINALE** (Song by Mino Reitano): [Link](https://www.youtube.com/watch?v=rlwuYMo-_Es)
+10. **CANZONE FINALE** ("Arrivederci"): [Link](https://www.youtube.com/watch?v=au_mgfqv7A4&list=RDau_mgfqv7A4&start_radio=1)


### PR DESCRIPTION
Added a new page under `site/content/show` with the list of youtube links, formatted as clickable links with the text "Link" instead of exposing the raw YouTube ID.

---
*PR created automatically by Jules for task [2414138935995977691](https://jules.google.com/task/2414138935995977691) started by @zonca*