### PR TITLE
Summer 2026 Session Setup

### DIFF
--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -18,69 +18,40 @@ Note: All in-person adult classes meet at our school at [4550 Kearny Villa Rd Su
 
 ## Italian for Travelers
 
-
-
 Planning a trip to Italy? Get ready with our "Italian for Travelers" program! We are launching three separate sessions for March, April, and May 2026.
 
-
-
 <div class="tc">
-
 <a href="{{< relref "news/italian-for-travelers-march-april-may-2026.md" >}}" class="btn raise">Learn more and enroll to "Italian for travelers"</a>
-
 </div>
-
-
 
 ---
 
+## Summer 2026 Group Classes
 
-
-## January-May 2026 Group Classes
-
-
-
+Our summer session runs for **10 weeks** from **June 1st to August 7th**.
 Choose your level below and enroll online with your credit card.
-
-
 
 ### Beginner class
 
-
-
 No prior Italian experience required.
 
+Start your Italian journey with our friendly, hands-on beginner class! In 10 weeks, you'll build a solid foundation in Italian conversation, vocabulary, and culture—perfect for travel, work, or connecting with family. We offer both in-person and online Zoom sessions.
 
-
-Start your Italian journey with our friendly, hands-on beginner class! In 5 months, you'll build a solid foundation in Italian conversation, vocabulary, and culture—perfect for travel, work, or connecting with family. Our small group setting ensures plenty of personal attention and practice. Whether you're brand new to Italian or want a refresher, you'll feel welcome and supported every step of the way.
-
-**New session starting in April!** We just added a new Tuesday beginner section:
-
-<div class="tc"><a href='{{< relref "news/new-tuesday-beginner-italian-class-march-may-2026.md" >}}' class="btn raise">New Tuesday In-person Beginner (April–May)</a></div>
-
-
-
-
-
-
-
-<div class="tc"><a href='{{< relref "news/adult-beginner-classes-january-may-2026.md" >}}' class="btn raise">View standard beginner schedule & tuition</a></div>
-
-
+<div class="tc"><a href='{{< relref "news/adult-beginner-classes-summer-2026.md" >}}' class="btn raise">View summer beginner schedule & tuition</a></div>
 
 ### All intermediate levels
 
 For students with at least one year of Italian classes or equivalent self-study.
 
-We offer multiple intermediate tracks to keep you challenged and progressing, whether you're solidly intermediate or edging toward advanced. Review schedules, tuition, and enrollment links here: [All intermediate level classes (January–May 2026)]({{< relref "news/adult-intermediate-classes-january-may-2026.md" >}})
-<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-january-may-2026.md" >}}' class="btn raise">View intermediate schedules & tuition</a></div>
+We offer multiple intermediate tracks to keep you challenged and progressing, whether you're solidly intermediate or edging toward advanced.
+
+<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-summer-2026.md" >}}' class="btn raise">View summer intermediate schedules & tuition</a></div>
 
 ### Advanced
 
 For students with 3+ years of Italian, able to understand most spoken Italian and hold conversations.
 
-Find the full schedule, tuition, and teacher details here: [Advanced classes (January–May 2026)]({{< relref "news/adult-advanced-classes-january-may-2026.md" >}})
-<div class="tc"><a href='{{< relref "news/adult-advanced-classes-january-may-2026.md" >}}' class="btn raise">View advanced schedule & tuition</a></div>
+<div class="tc"><a href='{{< relref "news/adult-advanced-classes-summer-2026.md" >}}' class="btn raise">View summer advanced schedule & tuition</a></div>
 
 ## Private & Custom Classes
 
@@ -111,6 +82,7 @@ We offer custom classes online, at our location, or even at your home. [Contact 
 
 ## Previous Sessions
 
+- [January-May 2026]( {{< ref "news/adult-beginner-classes-january-may-2026.md" >}} )
 - [Fall 2025]( {{< ref "news/italian-adult-classes-fall-2025.md" >}} )
 - [Summer 2025 session]( {{< ref "news/italian-adult-classes-summer-2025.md" >}} )
 

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -39,11 +39,11 @@ Start your Italian journey with our friendly, hands-on beginner class! In 10 wee
 
 <div class="tc"><a href='{{< relref "news/adult-beginner-classes-summer-2026.md" >}}' class="btn raise">View summer beginner schedule & tuition</a></div>
 
-### All intermediate levels
+### Intermediate & Intermediate-Advanced
 
 For students with at least one year of Italian classes or equivalent self-study.
 
-We offer multiple intermediate tracks to keep you challenged and progressing, whether you're solidly intermediate or edging toward advanced.
+We offer multiple tracks to keep you challenged and progressing, including a combined **Evaluation Day on June 1st** for our Monday students to ensure the best level placement.
 
 <div class="tc"><a href='{{< relref "news/adult-intermediate-classes-summer-2026.md" >}}' class="btn raise">View summer intermediate schedules & tuition</a></div>
 

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -26,6 +26,14 @@ Planning a trip to Italy? Get ready with our "Italian for Travelers" program! We
 
 ---
 
+## Spanish for Adults
+
+Interested in learning another Romance language? We are launching a new Spanish beginner class this summer!
+
+<div class="tc"><a href="{{< relref "news/adult-spanish-classes-summer-2026.md" >}}" class="btn raise">View summer Spanish schedule & tuition</a></div>
+
+---
+
 ## Summer 2026 Group Classes
 
 Our summer session runs for **10 weeks** from **June 1st to August 7th**.

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -104,7 +104,6 @@ To request a refund, email `admin` at our domain `italianschoolsd.com`.
 
 ### Family Discount
 
-- 10% off for all additional family members (except for "Italian for Travelers," which has its own discount policy).
-Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 ---

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -106,4 +106,3 @@ To request a refund, email `admin` at our domain `italianschoolsd.com`.
 
 - 10% off for all additional family members (applied automatically at checkout).
 
----

--- a/site/content/news/adult-advanced-classes-summer-2026.md
+++ b/site/content/news/adult-advanced-classes-summer-2026.md
@@ -21,4 +21,10 @@ This conversation-only class focuses on lively discussion and oral communication
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-conversation-thursday/Y5WKFUFESRXU4N6FUGYEQWBD' class="btn raise">Pay and enroll (Thursday Conversation, $350)</a></div>
 
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+
 Questions about whether this class is the right fit? [Contact us]({{< relref "contact.md" >}}) and we’ll talk through placement.

--- a/site/content/news/adult-advanced-classes-summer-2026.md
+++ b/site/content/news/adult-advanced-classes-summer-2026.md
@@ -24,7 +24,6 @@ This conversation-only class focuses on lively discussion and oral communication
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 Questions about whether this class is the right fit? [Contact us]({{< relref "contact.md" >}}) and we’ll talk through placement.

--- a/site/content/news/adult-advanced-classes-summer-2026.md
+++ b/site/content/news/adult-advanced-classes-summer-2026.md
@@ -1,0 +1,33 @@
+---
+title: Advanced Adult Italian Classes — Summer 2026
+date: 2026-05-11
+description: Advanced-level adult Italian class schedule, tuition, and enrollment information for June through August 2026.
+---
+
+Comfortable holding conversations in Italian and ready to dive deeper into nuance, culture, and speed? Our advanced section keeps you thinking in Italian with authentic materials and lively discussion each week. Students typically have 3+ years of study or equivalent immersion experience.
+
+Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+
+For other levels see [Adult classes overview]({{< relref "adults.md" >}}) for quick comparisons, policies, and discounts.
+
+---
+
+## Monday Intermediate-Advanced
+
+- **Schedule:** Mondays, 6:00 pm–7:30 pm, June 1 – August 3, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-int-adv-monday/GVLL75X5J5WKWA2VFTL7RDDU' class="btn raise">Pay and enroll (Monday Int-Adv, $350)</a></div>
+
+---
+
+## Thursday Advanced Conversation
+
+- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+This conversation-only class focuses on lively discussion and oral communication. There are no written exercises, and grammar is addressed only when necessary to support conversational flow. We will use articles and blog posts as engaging topics for discussion.
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-conversation-thursday/Y5WKFUFESRXU4N6FUGYEQWBD' class="btn raise">Pay and enroll (Thursday Conversation, $350)</a></div>
+
+Questions about whether this class is the right fit? [Contact us]({{< relref "contact.md" >}}) and we’ll talk through placement.

--- a/site/content/news/adult-advanced-classes-summer-2026.md
+++ b/site/content/news/adult-advanced-classes-summer-2026.md
@@ -1,5 +1,5 @@
 ---
-title: Advanced Adult Italian Classes — Summer 2026
+title: "Advanced Adult Italian Classes — Summer 2026"
 date: 2026-05-11
 description: Advanced-level adult Italian class schedule, tuition, and enrollment information for June through August 2026.
 ---
@@ -9,15 +9,6 @@ Comfortable holding conversations in Italian and ready to dive deeper into nuanc
 Our summer session runs for **10 weeks** from **June 1st to August 7th**.
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}) for quick comparisons, policies, and discounts.
-
----
-
-## Monday Intermediate-Advanced
-
-- **Schedule:** Mondays, 6:00 pm–7:30 pm, June 1 – August 3, 2026 (10 classes)
-- **Tuition:** $350 for the full session
-
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-int-adv-monday/GVLL75X5J5WKWA2VFTL7RDDU' class="btn raise">Pay and enroll (Monday Int-Adv, $350)</a></div>
 
 ---
 

--- a/site/content/news/adult-advanced-classes-summer-2026.md
+++ b/site/content/news/adult-advanced-classes-summer-2026.md
@@ -21,6 +21,7 @@ This conversation-only class focuses on lively discussion and oral communication
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-conversation-thursday/Y5WKFUFESRXU4N6FUGYEQWBD' class="btn raise">Pay and enroll (Thursday Conversation, $350)</a></div>
 
+---
 
 ### Family Discount
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -1,8 +1,7 @@
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 ---
 title: Beginner Adult Italian Classes — Summer 2026
@@ -11,8 +10,7 @@ description: Full schedule, tuition, and enrollment links for beginner-level adu
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 ---
 
@@ -25,8 +23,7 @@ For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 ---
 
@@ -44,8 +41,7 @@ Start your Italian journey in person at our school!
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 ---
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -1,17 +1,7 @@
-
-### Family Discount
-
-- 10% off for all additional family members (applied automatically at checkout).
-
 ---
 title: Beginner Adult Italian Classes — Summer 2026
 date: 2026-05-11
 description: Full schedule, tuition, and enrollment links for beginner-level adult Italian classes running June through August 2026.
-
-### Family Discount
-
-- 10% off for all additional family members (applied automatically at checkout).
-
 ---
 
 Need a friendly place to start your Italian? These beginner sections keep things practical, interactive, and low-pressure so you can build confidence quickly. No prior Italian experience is required—come ready to learn from the ground up.
@@ -19,11 +9,6 @@ Need a friendly place to start your Italian? These beginner sections keep things
 Our summer session runs for **10 weeks** from **June 1st to August 7th**.
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.
-
-
-### Family Discount
-
-- 10% off for all additional family members (applied automatically at checkout).
 
 ---
 
@@ -38,11 +23,6 @@ Start your Italian journey in person at our school!
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-thursday/OYEAS2PQXC2JDLNRICVRRWXB' class="btn raise">Pay and enroll (Thursday Beginner, In person, $360)</a></div>
 <div class="tc"><a href='https://italianschoolsd.square.site/bundle' class="btn raise">Pay and enroll (Thursday Beginner + Book Bundle, $409)</a></div>
 
-
-### Family Discount
-
-- 10% off for all additional family members (applied automatically at checkout).
-
 ---
 
 ## Monday Beginner (Online)
@@ -50,9 +30,15 @@ Start your Italian journey in person at our school!
 Learn Italian from the comfort of your home via Zoom.
 
 - **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 1 – August 3, 2026 (10 classes)
-- **Tuition:** $360 for the full session (payment link below)
+- **Tuition:** $330 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>
+
+---
+
+### Family Discount
+
+- 10% off for all additional family members (applied automatically at checkout).
 
 Questions about placement? [Contact us]({{< relref "contact.md" >}}) and we’ll help you choose the best fit.

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -1,0 +1,38 @@
+---
+title: Beginner Adult Italian Classes — Summer 2026
+date: 2026-05-11
+description: Full schedule, tuition, and enrollment links for beginner-level adult Italian classes running June through August 2026.
+---
+
+Need a friendly place to start your Italian? These beginner sections keep things practical, interactive, and low-pressure so you can build confidence quickly. No prior Italian experience is required—come ready to learn from the ground up.
+
+Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+
+For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.
+
+---
+
+## Thursday Beginner (In person)
+
+Start your Italian journey in person at our school!
+
+- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
+- **Tuition:** $360 for the full session (payment link below)
+- **Textbook:** This class uses 'New Italian Project 1a'. You can purchase it separately or choose the bundle below.
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-thursday/OYEAS2PQXC2JDLNRICVRRWXB' class="btn raise">Pay and enroll (Thursday Beginner, In person, $360)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-beginner-italian-class-book-bundle/UZXFKTAH3LIU46VETSIL66MT' class="btn raise">Pay and enroll (Thursday Beginner + Book Bundle, $409)</a></div>
+
+---
+
+## Monday Beginner (Online)
+
+Learn Italian from the comfort of your home via Zoom.
+
+- **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 1 – August 3, 2026 (10 classes)
+- **Tuition:** $360 for the full session (payment link below)
+- **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $360)</a></div>
+
+Questions about placement? [Contact us]({{< relref "contact.md" >}}) and we’ll help you choose the best fit.

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -1,7 +1,19 @@
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+
 ---
 title: Beginner Adult Italian Classes — Summer 2026
 date: 2026-05-11
 description: Full schedule, tuition, and enrollment links for beginner-level adult Italian classes running June through August 2026.
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+
 ---
 
 Need a friendly place to start your Italian? These beginner sections keep things practical, interactive, and low-pressure so you can build confidence quickly. No prior Italian experience is required—come ready to learn from the ground up.
@@ -9,6 +21,12 @@ Need a friendly place to start your Italian? These beginner sections keep things
 Our summer session runs for **10 weeks** from **June 1st to August 7th**.
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.
+
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
 
 ---
 
@@ -22,6 +40,12 @@ Start your Italian journey in person at our school!
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-thursday/OYEAS2PQXC2JDLNRICVRRWXB' class="btn raise">Pay and enroll (Thursday Beginner, In person, $360)</a></div>
 <div class="tc"><a href='https://italianschoolsd.square.site/bundle' class="btn raise">Pay and enroll (Thursday Beginner + Book Bundle, $409)</a></div>
+
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
 
 ---
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -21,7 +21,7 @@ Start your Italian journey in person at our school!
 - **Textbook:** This class uses 'New Italian Project 1a'. You can purchase it separately or choose the bundle below.
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-thursday/OYEAS2PQXC2JDLNRICVRRWXB' class="btn raise">Pay and enroll (Thursday Beginner, In person, $360)</a></div>
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-beginner-italian-class-book-bundle/UZXFKTAH3LIU46VETSIL66MT' class="btn raise">Pay and enroll (Thursday Beginner + Book Bundle, $409)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/bundle' class="btn raise">Pay and enroll (Thursday Beginner + Book Bundle, $409)</a></div>
 
 ---
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -33,6 +33,6 @@ Learn Italian from the comfort of your home via Zoom.
 - **Tuition:** $360 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $360)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>
 
 Questions about placement? [Contact us]({{< relref "contact.md" >}}) and we’ll help you choose the best fit.

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -1,0 +1,51 @@
+---
+title: Intermediate Adult Italian Classes — Summer 2026
+date: 2026-05-11
+description: Schedule and tuition details for intermediate-level adult Italian classes offered June through August 2026.
+---
+
+Have at least a year of Italian under your belt—or the equivalent through self-study? Our intermediate tracks help you strengthen grammar, vocabulary, and conversational agility while keeping lessons lively and collaborative.
+
+Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+
+For other levels see [Adult classes overview]({{< relref "adults.md" >}}), which also covers policies and discounts.
+
+---
+
+## Monday Intermediate
+
+- **Schedule:** Mondays, 6:00 pm–7:30 pm, June 1 – August 3, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-intermediate-monday/YQTVZXBRXOQLBX3KVGZI4L2W' class="btn raise">Pay and enroll (Monday Intermediate, $350)</a></div>
+
+---
+
+## Tuesday Beginner-Intermediate (Easier Track)
+
+- **Schedule:** Tuesdays, 5:30 pm–7:00 pm, June 2 – August 4, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-easier-tuesday/VLOMIQVBYSVGNH2PFTS2SVMO' class="btn raise">Pay and enroll (Tuesday Beg-Int, $350)</a></div>
+
+---
+
+## Wednesday Intermediate
+
+- **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 3 – August 5, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-intermediate-wednesday/4PVRPINFT5UZ365N7UINJ3NH' class="btn raise">Pay and enroll (Wednesday Intermediate, $350)</a></div>
+
+---
+
+## Thursday Beginner-Intermediate (Challenging Track)
+
+- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-challenging-thursday/2L3BIIX5PKGKFXL5XYPDRJ63' class="btn raise">Pay and enroll (Thursday Beg-Int, $350)</a></div>
+
+---
+
+Need help choosing between sections? [Contact us]({{< relref "contact.md" >}}) and we’ll point you in the right direction.

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -60,7 +60,6 @@ These classes are designed for students moving up from our Beginner level or tho
 
 ### Family Discount
 
-- 10% off for all additional family members.
-- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+- 10% off for all additional family members (applied automatically at checkout).
 
 Need help choosing between sections? [Contact us]({{< relref "contact.md" >}}) and we’ll point you in the right direction.

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -57,7 +57,6 @@ These classes are designed for students moving up from our Beginner level or tho
 
 ---
 
-
 ### Family Discount
 
 - 10% off for all additional family members (applied automatically at checkout).

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -12,6 +12,31 @@ For other levels see [Adult classes overview]({{< relref "adults.md" >}}), which
 
 ---
 
+## Beginner-Intermediate Tracks
+
+These classes are designed for students moving up from our Beginner level or those with equivalent experience. We offer two tracks based on your pace:
+
+*   **Easier Track (Tuesday):** Best for students who have studied Italian for approximately **2 months**.
+*   **Challenging Track (Thursday):** Best for students who have studied Italian for approximately **4 months**.
+
+### Tuesday Beginner-Intermediate (Easier Track)
+
+- **Schedule:** Tuesdays, 5:30 pm–7:00 pm, June 2 – August 4, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-easier-tuesday/VLOMIQVBYSVGNH2PFTS2SVMO' class="btn raise">Pay and enroll (Tuesday Beg-Int, $350)</a></div>
+
+---
+
+### Thursday Beginner-Intermediate (Challenging Track)
+
+- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
+- **Tuition:** $350 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-challenging-thursday/2L3BIIX5PKGKFXL5XYPDRJ63' class="btn raise">Pay and enroll (Thursday Beg-Int, $350)</a></div>
+
+---
+
 ## Monday All Intermediate Levels
 
 - **Schedule:** Mondays, 6:00 pm–7:30 pm, June 1 – August 3, 2026 (10 classes)
@@ -23,30 +48,12 @@ For other levels see [Adult classes overview]({{< relref "adults.md" >}}), which
 
 ---
 
-## Tuesday Beginner-Intermediate (Easier Track)
-
-- **Schedule:** Tuesdays, 5:30 pm–7:00 pm, June 2 – August 4, 2026 (10 classes)
-- **Tuition:** $350 for the full session
-
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-easier-tuesday/VLOMIQVBYSVGNH2PFTS2SVMO' class="btn raise">Pay and enroll (Tuesday Beg-Int, $350)</a></div>
-
----
-
 ## Wednesday Intermediate
 
 - **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 3 – August 5, 2026 (10 classes)
 - **Tuition:** $350 for the full session
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-intermediate-wednesday/4PVRPINFT5UZ365N7UINJ3NH' class="btn raise">Pay and enroll (Wednesday Intermediate, $350)</a></div>
-
----
-
-## Thursday Beginner-Intermediate (Challenging Track)
-
-- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
-- **Tuition:** $350 for the full session
-
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beg-int-challenging-thursday/2L3BIIX5PKGKFXL5XYPDRJ63' class="btn raise">Pay and enroll (Thursday Beg-Int, $350)</a></div>
 
 ---
 

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -12,12 +12,14 @@ For other levels see [Adult classes overview]({{< relref "adults.md" >}}), which
 
 ---
 
-## Monday Intermediate
+## Monday All Intermediate Levels
 
 - **Schedule:** Mondays, 6:00 pm–7:30 pm, June 1 – August 3, 2026 (10 classes)
+- **Structure:** We plan to run two groups (**Intermediate** and **Intermediate-Advanced**) simultaneously and place students according to their level. **June 1st is an “Evaluation Day”** to help balance the groups and ensure everyone is in the right track.
 - **Tuition:** $350 for the full session
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-intermediate-monday/YQTVZXBRXOQLBX3KVGZI4L2W' class="btn raise">Pay and enroll (Monday Intermediate, $350)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-int-adv-monday/GVLL75X5J5WKWA2VFTL7RDDU' class="btn raise">Pay and enroll (Monday Intermediate-Advanced, $350)</a></div>
 
 ---
 

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -57,4 +57,10 @@ These classes are designed for students moving up from our Beginner level or tho
 
 ---
 
+
+### Family Discount
+
+- 10% off for all additional family members.
+- Please pay the full amount, then [contact us](https://www.italianschoolsd.com/contact/) for your partial refund.
+
 Need help choosing between sections? [Contact us]({{< relref "contact.md" >}}) and we’ll point you in the right direction.

--- a/site/content/news/adult-spanish-classes-summer-2026.md
+++ b/site/content/news/adult-spanish-classes-summer-2026.md
@@ -1,0 +1,28 @@
+---
+title: Beginner Spanish for Adults — Summer 2026
+date: 2026-05-11
+description: Enrollment and schedule for our new beginner-level Spanish class for adults.
+---
+
+Expand your linguistic horizons this summer! We are excited to offer a new **Spanish for Adults** beginner track. This class is designed for absolute beginners and is taught by a bilingual instructor who can help bridge the gap between English, Italian, and Spanish.
+
+Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+
+For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.
+
+---
+
+## Thursday Spanish Beginner (In person)
+
+- **Schedule:** Thursdays, 6:00 pm–7:30 pm, June 4 – August 6, 2026 (10 classes)
+- **Tuition:** $360 for the full session
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-spanish-class-beginner-thursday/FQRBMFIFIJ4EDG4KUTO3TE43' class="btn raise">Pay and enroll (Thursday Spanish Beginner, $360)</a></div>
+
+---
+
+### Family Discount
+
+- 10% off for all additional family members (applied automatically at checkout).
+
+Questions about placement? [Contact us]({{< relref "contact.md" >}}) and we’ll help you choose the best fit.

--- a/site/content/news/adult-spanish-classes-summer-2026.md
+++ b/site/content/news/adult-spanish-classes-summer-2026.md
@@ -6,6 +6,8 @@ description: Enrollment and schedule for our new beginner-level Spanish class fo
 
 Expand your linguistic horizons this summer! We are excited to offer a new **Spanish for Adults** beginner track. This class is designed for absolute beginners and is taught by a bilingual instructor who can help bridge the gap between English, Italian, and Spanish.
 
+Spanish and Italian are very similar languages, making this a great opportunity to study them together and accelerate your learning in both!
+
 Our summer session runs for **10 weeks** from **June 1st to August 7th**.
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.


### PR DESCRIPTION
This PR adds the news posts for the Summer 2026 session (June-August) and updates the adult classes overview page with new Square enrollment links.