### PR TITLE
Postpone Wednesday summer classes by 1 week

### DIFF
--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -36,7 +36,7 @@ Interested in learning another Romance language? We are launching a new Spanish 
 
 ## Summer 2026 Group Classes {#summer-2026}
 
-Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+Our summer session runs for **10 weeks** from **June 1st to August 12th**.
 
 ## Detailed Weekly Schedule (All classes 1.5 hours)
 

--- a/site/content/news/adult-intermediate-classes-summer-2026.md
+++ b/site/content/news/adult-intermediate-classes-summer-2026.md
@@ -6,7 +6,7 @@ description: Schedule and tuition details for intermediate-level adult Italian c
 
 Have at least a year of Italian under your belt—or the equivalent through self-study? Our intermediate tracks help you strengthen grammar, vocabulary, and conversational agility while keeping lessons lively and collaborative.
 
-Our summer session runs for **10 weeks** from **June 1st to August 7th**. All our teachers are native Italian speakers (Italian mother tongue).
+Our summer session runs for **10 weeks** from **June 1st to August 12th**. All our teachers are native Italian speakers (Italian mother tongue).
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}), which also covers policies and discounts.
 
@@ -67,7 +67,7 @@ Learn Italian from anywhere via Zoom with **Tania**!
 
 ## Wednesday Intermediate {#wed-int}
 
-- **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 3 – August 5, 2026 (10 classes)
+- **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 10 – August 12, 2026 (10 classes)
 - **Teacher:** **Laura**
 - **Tuition:** $350 for the full session
 

--- a/site/content/news/adult-spanish-classes-summer-2026.md
+++ b/site/content/news/adult-spanish-classes-summer-2026.md
@@ -8,7 +8,7 @@ Expand your linguistic horizons this summer! We are excited to offer a new **Spa
 
 Spanish and Italian are very similar languages, making this a great opportunity to study them together and accelerate your learning in both!
 
-Our summer session runs for **10 weeks** from **June 1st to August 7th**.
+Our summer session runs for **10 weeks** from **June 1st to August 12th**.
 
 For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where you’ll also find policies and discounts.
 
@@ -16,7 +16,7 @@ For other levels see [Adult classes overview]({{< relref "adults.md" >}}), where
 
 ## Wednesday Spanish Beginner (In person) {#wed-spanish}
 
-- **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 3 – August 5, 2026 (10 classes)
+- **Schedule:** Wednesdays, 6:00 pm–7:30 pm, June 10 – August 12, 2026 (10 classes)
 - **Tuition:** $360 for the full session
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-spanish-class-beginner-thursday/FQRBMFIFIJ4EDG4KUTO3TE43' class="btn raise">Pay and enroll (Wednesday Spanish Beginner, $360)</a></div>


### PR DESCRIPTION
This PR postpones the Wednesday summer classes (Italian Intermediate and Spanish Beginner) to start on June 10th and end on August 12th, to avoid overlap with the finishing Spring session.