### PR TITLE
Start Monday Beginner (Online) on June 8th (10 classes)

### DIFF
--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -33,7 +33,7 @@ Learn Italian from the comfort of your home via Zoom with **Tania**.
 - **Tuition:** $297 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $297)</a></div>
 
 ---
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -30,7 +30,7 @@ Start your Italian journey in person at our school with **Valentina**!
 Learn Italian from the comfort of your home via Zoom with **Tania**.
 
 - **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 8 – August 10, 2026 (10 classes)
-- **Tuition:** $297 for the full session (payment link below)
+- **Tuition:** $330 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -29,7 +29,7 @@ Start your Italian journey in person at our school with **Valentina**!
 
 Learn Italian from the comfort of your home via Zoom with **Tania**.
 
-- **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 1 – August 3, 2026 (10 classes)
+- **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 8 – August 10, 2026 (10 classes)
 - **Tuition:** $297 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 

--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -33,7 +33,7 @@ Learn Italian from the comfort of your home via Zoom with **Tania**.
 - **Tuition:** $297 for the full session (payment link below)
 - **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $297)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>
 
 ---
 


### PR DESCRIPTION
This PR performs a surgical update to the Summer 2026 Monday Online Beginner class.

Changes:
- Delayed the start date to **June 8th**.
- Fixed the schedule to exactly **10 classes** (ending August 10th).
- Corrected the tuition text to **$330**.

All other session dates, including the general session duration and the Enrollment/Evaluation Day (June 1st), have been kept unchanged as they are only for in-person classes.

Relates to [ZON-25](mention://issue/99bfb42a-ab07-4f66-8025-65a003ca8458)