### PR TITLE
Fix Monday Online textbook to Nuovo Espresso 1

### DIFF
--- a/site/content/news/adult-beginner-classes-summer-2026.md
+++ b/site/content/news/adult-beginner-classes-summer-2026.md
@@ -31,7 +31,7 @@ Learn Italian from the comfort of your home via Zoom with **Tania**.
 
 - **Schedule:** Mondays, 6:00 pm–7:30 pm PST, June 8 – August 10, 2026 (10 classes)
 - **Tuition:** $330 for the full session (payment link below)
-- **Textbook:** This class uses 'New Italian Project 1a'. Please purchase it independently (no bundle available for online classes).
+- **Textbook:** This class uses 'Nuovo Espresso 1' ([available on Amazon](https://www.amazon.com/Nuovo-Espresso-Libro-studente-interattivo/dp/8861826725)).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/summer-2026-italian-class-beginner-monday-online/ERN5QKWOVHCDS35OQPNFIVMO' class="btn raise">Pay and enroll (Monday Beginner, Online, $330)</a></div>
 


### PR DESCRIPTION
The Monday Online beginner class uses Nuovo Espresso 1, not New Italian Project 1a. Updated the textbook line with the Amazon link and removed the bundle note (we don't sell this book).

🤖 Generated with [Claude Code](https://claude.com/claude-code)