### PR TITLE
Fix translate page layout

### DIFF
--- a/site/layouts/translate/list.html
+++ b/site/layouts/translate/list.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+{{ partial "jumbotron" (dict "imageUrl" .Params.image "title" .Title "subtitle" .Params.subtitle) }}
+<div class="bg-off-white pv4">
+  <div class="ph3 mw7 center cms">
+      {{ .Content }}
+  </div>
+</div>
+{{ end }}

--- a/site/layouts/translate/single.html
+++ b/site/layouts/translate/single.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+{{ partial "jumbotron" (dict "imageUrl" .Params.image "title" .Title "subtitle" .Params.subtitle) }}
+<div class="bg-off-white pv4">
+  <div class="ph3 mw7 center cms">
+      {{ .Content }}
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
Fixes the issue where the /translate page turned into a blog index after adding subpages.

---
*PR created automatically by Jules for task [12806597614273932765](https://jules.google.com/task/12806597614273932765) started by @zonca*