### PR TITLE
Add In-Person Italian Classes in La Jolla

### DIFF
--- a/site/assets/css/imports/_cms.scss
+++ b/site/assets/css/imports/_cms.scss
@@ -46,6 +46,17 @@
 		}
 	}
 
+	& a.checkout-button {
+		color: var(--white);
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			background-color: var(--highlight);
+			color: var(--white);
+		}
+	}
+
 	/* Lists */
 	& ul, & ol, & li {
 		position: relative;

--- a/site/assets/css/imports/_forms.scss
+++ b/site/assets/css/imports/_forms.scss
@@ -14,7 +14,7 @@ fieldset
   padding: 0;
 }
 
-input, textarea {
+input, textarea, select {
   background-color: var(--grey-2);
   border-radius: var(--border-radius);
   padding: 12px 16px 10px;
@@ -31,6 +31,26 @@ input, textarea {
     pointer-events: auto;
     transform: translateY(-120%);
   }
+}
+
+select {
+  border: 0;
+  min-height: 3.25rem;
+}
+
+.contact-select-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.contact-select-label {
+  background-color: transparent;
+  color: var(--primary);
+  margin-bottom: var(--spacing-extra-small);
+  opacity: 1;
+  padding: 0;
+  pointer-events: auto;
+  position: static;
 }
 
 ::-webkit-input-placeholder {

--- a/site/assets/css/imports/_styles.scss
+++ b/site/assets/css/imports/_styles.scss
@@ -46,6 +46,186 @@
   margin-top: auto;
 }
 
+.checkout-options {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin: var(--spacing-medium) 0;
+}
+
+.checkout-card {
+  align-content: start;
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-radius: 0.4rem;
+  box-shadow: 0 8px 20px rgba(43, 37, 35, 0.06);
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin: 0;
+  padding: 0.7rem;
+  transition: box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.checkout-card:hover,
+.checkout-card:focus-within {
+  border-color: rgba(0, 100, 170, 0.28);
+  box-shadow: 0 10px 24px rgba(0, 100, 170, 0.1);
+}
+
+.checkout-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.checkout-label {
+  background: transparent;
+  color: var(--grey-4);
+  font-size: 0.74rem;
+  font-weight: 800;
+  line-height: 1.1;
+  opacity: 1;
+  padding: 0;
+  pointer-events: auto;
+  position: static;
+}
+
+.checkout-select {
+  appearance: none;
+  background:
+    linear-gradient(45deg, transparent 50%, var(--primary) 50%),
+    linear-gradient(135deg, var(--primary) 50%, transparent 50%),
+    linear-gradient(180deg, var(--white), var(--grey-1));
+  background-position: calc(100% - 1rem), calc(100% - 0.7rem), 0 0;
+  background-repeat: no-repeat;
+  background-size: 0.32rem 0.32rem, 0.32rem 0.32rem, 100% 100%;
+  border: 1px solid rgba(0, 100, 170, 0.22);
+  border-radius: 0.35rem;
+  color: var(--black);
+  font-weight: 700;
+  min-height: 2.45rem;
+  max-width: 100%;
+  padding: 0 2rem 0 0.7rem;
+  width: 100%;
+}
+
+.checkout-select:focus {
+  border-color: var(--highlight);
+  box-shadow: 0 0 0 3px rgba(13, 155, 255, 0.18);
+  outline: 0;
+}
+
+.checkout-commitment {
+  align-items: flex-start;
+  background: transparent;
+  border-radius: 0;
+  color: var(--grey-4);
+  display: flex;
+  font-size: 0.82rem;
+  font-weight: 700;
+  gap: 0.45rem;
+  left: auto;
+  line-height: 1.3;
+  opacity: 1;
+  padding: 0;
+  pointer-events: auto;
+  position: static;
+  top: auto;
+  z-index: auto;
+}
+
+.checkout-commitment input {
+  background: transparent;
+  border-radius: 0;
+  flex: none;
+  margin-top: 0.15rem;
+  padding: 0;
+  z-index: auto;
+}
+
+.checkout-commitment a {
+  color: var(--primary);
+}
+
+.checkout-button {
+  border: 0;
+  border-radius: 0.45rem;
+  background: var(--primary);
+  box-shadow: 0 8px 18px rgba(0, 100, 170, 0.18);
+  color: var(--white);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font: inherit;
+  gap: 0.05rem;
+  justify-content: center;
+  margin: 0.25rem 0 0;
+  min-height: 3rem;
+  padding: 0.5rem 0.85rem;
+  text-align: center;
+  transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.checkout-button:hover,
+.checkout-button:focus {
+  background: var(--highlight);
+  box-shadow: 0 10px 22px rgba(0, 100, 170, 0.24);
+  color: var(--white);
+  transform: translateY(-1px);
+}
+
+.checkout-button:focus {
+  outline: 3px solid rgba(13, 155, 255, 0.25);
+  outline-offset: 2px;
+}
+
+.checkout-button span {
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.checkout-button strong {
+  font-size: 1.08rem;
+  line-height: 1.15;
+}
+
+.checkout-button small {
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.1;
+  opacity: 0.9;
+}
+
+.checkout-note {
+  color: var(--grey-3);
+  font-size: 0.9rem;
+  line-height: 1.35;
+  margin: 0.15rem 0 0;
+  text-align: center;
+}
+
+@media (--breakpoint-not-small) {
+  .checkout-options {
+    grid-template-columns: repeat(2, minmax(15rem, 1fr));
+  }
+
+  .checkout-card-full {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .checkout-card-full .checkout-button {
+    grid-column: 1 / -1;
+  }
+
+  .checkout-note {
+    grid-column: 1 / -1;
+  }
+}
+
 .site-footer {
   background:
     radial-gradient(1200px 600px at 10% 0%, rgba(13, 155, 255, 0.18), transparent 55%),

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -69,6 +69,12 @@ Advanced and Conversation classes will resume in the Fall. In the meantime, adva
 
 ## Private & Custom Classes {#private-custom}
 
+### In-Person Italian Classes in La Jolla {#la-jolla}
+
+Prefer to learn in La Jolla? We offer private lessons with a native Italian teacher in a prestigious office on **Fay Ave**, near **The Lot La Jolla**. Learn solo or with a friend.
+
+<div class="tc"><a href='{{< relref "italian-in-person-classes-la-jolla.md" >}}' class="btn raise">Learn more about La Jolla in-person classes</a></div>
+
 ### Private Lessons (In-person or via Zoom) {#private}
 
 One-on-one lessons tailored to your level and interests, from absolute beginner to advanced. All our instructors are experienced, native Italian speakers. Enjoy flexible scheduling and a 24-hour cancellation policy.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -39,7 +39,7 @@ Get started with a package of five one-hour lessons, and book more whenever you'
 
 1. Purchase your package above with your credit card.
 2. We reach out to set up a short call to discuss your goals and find times that work for you.
-3. Start learning in La Jolla. When your 5 hours are up, book another package to continue.
+3. Start learning in La Jolla. When you finish your five lessons, book another package to continue.
 
 ## Give the gift of Italian {#gift}
 

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -1,0 +1,56 @@
+---
+title: In-Person Italian Classes in La Jolla
+image: /img/positano-flag.jpg
+aliases:
+    - /la-jolla
+subtitle: Private Italian lessons in a prestigious La Jolla office, scheduled around you
+---
+
+Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lessons take place in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and tailored to your level, goals, and pace. Schedule **weekdays from 2 PM onward, or anytime on weekends**.
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+</div>
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+</div>
+
+---
+
+## Why Choose These Classes? {#why}
+
+- **Prestigious La Jolla location** — a professional office on Fay Ave, near The Lot La Jolla.
+- **Native Italian teacher** — all our instructors are native Italian speakers with experience teaching adults at every level.
+- **Flexible scheduling** — meet **weekdays from 2 PM onward, or anytime on weekends**. We build the schedule around you.
+- **One or two students** — learn solo, or split the lessons with a partner, friend, or colleague.
+- **Tailored to you** — from absolute beginner to advanced, every lesson is built around your goals.
+
+---
+
+## Pricing {#pricing}
+
+We ask for a **5-hour commitment** to get started:
+
+| Students | 5-hour package |
+| :--- | :--- |
+| **1 person** | **$599** |
+| **2 people** | **$799** |
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+</div>
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+</div>
+
+---
+
+## How It Works {#how-it-works}
+
+1. **Purchase your 5-hour package** above with your credit card.
+2. **We contact you to schedule** — after your purchase, we'll reach out to arrange your lessons for any day and time that works for you.
+3. **Start learning** in La Jolla with your native Italian teacher.
+
+Questions? [Contact us](/contact) — we're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -20,7 +20,7 @@ If you want focused instruction in a polished La Jolla setting, start with a fiv
 
 - **Five private one-hour lessons** per package, with a weekly rhythm recommended for steady progress.
 - **Convenient La Jolla setting** in a professional office on Fay Avenue, near The Lot La Jolla.
-- **Current availability**: Wednesday and Friday evenings after 6 PM.
+- **Current availability**: Wednesday and Friday evenings after 6 PM. If you prefer another time, [contact us](/contact) to inquire.
 - **One or two students**: choose dedicated individual instruction or a private pair format.
 - **Textbook included**, with nothing extra to buy.
 - **Personalized curriculum** for all levels, from beginner to advanced.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -15,7 +15,7 @@ Applying for **Italian citizenship**? We can prepare you for the **B1 language r
 ## What's included {#included}
 
 - **Five one-hour lessons** per package. We recommend one lesson a week.
-- **Current availability with Valentina**: Wednesday and Friday evenings after 6 PM, available through August 17, 2026.
+- **Current availability**: Wednesday and Friday evenings after 6 PM.
 - **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
 - **Textbook included**, with nothing extra to buy.
 - **All levels**, from beginner to advanced.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -8,6 +8,8 @@ subtitle: Private Italian lessons in a prestigious La Jolla office, scheduled ar
 
 Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lessons take place in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and tailored to your level, goals, and pace. Schedule **weekdays from 2 PM onward, or anytime on weekends**.
 
+Whatever brings you to Italian, we build the lessons around it: planning a trip to Italy, reconnecting with your family heritage, preparing for citizenship, getting ready for a move abroad, picking up the language for work, or simply learning for the joy of it.
+
 <div class="tc">
 <a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
@@ -25,6 +27,8 @@ Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lesson
 - **Flexible scheduling**: meet **weekdays from 2 PM onward, or anytime on weekends**. We build the schedule around you.
 - **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
 - **Tailored to you**: from absolute beginner to advanced, every lesson is built around your goals.
+- **Textbook included**: your book is part of the package, with nothing extra to buy.
+- **Flexible cancellation**: reschedule any lesson with at least 24 hours' notice.
 
 ---
 
@@ -50,7 +54,22 @@ We ask for a **5-hour commitment** to get started:
 ## How It Works {#how-it-works}
 
 1. **Purchase your 5-hour package** above with your credit card.
-2. **We contact you to schedule**: after your purchase, we'll reach out to arrange your lessons for any day and time that works for you.
-3. **Start learning** in La Jolla with your native Italian teacher.
+2. **We set up a call**: once you've booked, we'll reach out to schedule a short call to discuss your goals and find lesson times that work for you.
+3. **Start learning** in La Jolla with your native Italian teacher, textbook included.
+4. **Continue at your pace**: when you finish your 5 hours, simply book another package and keep going.
+
+---
+
+## Reschedule Policy {#reschedule}
+
+Life happens. You can reschedule any lesson at no charge with at least **24 hours' notice**. Just let your teacher know in advance and we'll find a new time.
+
+---
+
+## Give the Gift of Italian {#gift}
+
+Looking for a memorable present? A La Jolla lesson package makes a unique gift for the language lover, the traveler planning a trip to Italy, or anyone reconnecting with their heritage. Purchase a package above and [contact us](/contact) to have it set up as a gift, and we'll coordinate scheduling directly with the recipient.
+
+---
 
 Questions? [Contact us](/contact). We're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -6,31 +6,17 @@ aliases:
 subtitle: Private Italian lessons in a prestigious La Jolla office, scheduled around you
 ---
 
-Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lessons take place in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and tailored to your level, goals, and pace. Schedule **weekdays from 2 PM onward, or anytime on weekends**.
+Learn Italian one-on-one (or with a friend) in a prestigious office on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and built around your level, goals, and pace.
 
-Whatever brings you to Italian, we build the lessons around it: planning a trip to Italy, reconnecting with your family heritage, preparing for citizenship, getting ready for a move abroad, picking up the language for work, or simply learning for the joy of it.
+Whatever brings you to Italian, we shape the lessons around it: a trip to Italy, your family heritage, citizenship, a move abroad, or work.
 
-<div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
-</div>
+## What's included {#included}
 
-<div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
-</div>
-
----
-
-## Why choose these classes? {#why}
-
-- **Prestigious La Jolla location**: a professional office on Fay Ave, near The Lot La Jolla.
-- **Native Italian teacher**: all our instructors are native Italian speakers with experience teaching adults at every level.
-- **Flexible scheduling**: meet **weekdays from 2 PM onward, or anytime on weekends**. We build the schedule around you.
+- **Flexible scheduling**: weekdays from 2 PM onward, or anytime on weekends.
 - **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
-- **Tailored to you**: from absolute beginner to advanced, every lesson is built around your goals.
-- **Textbook included**: your book is part of the package, with nothing extra to buy.
-- **Flexible cancellation**: reschedule any lesson with at least 24 hours' notice.
-
----
+- **Textbook included**, with nothing extra to buy.
+- **All levels**, from absolute beginner to advanced.
+- **Free rescheduling** of any lesson with at least 24 hours' notice.
 
 ## Pricing {#pricing}
 
@@ -49,27 +35,14 @@ We ask for a **5-hour commitment** to get started:
 <a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
 </div>
 
----
-
 ## How it works {#how-it-works}
 
-1. **Purchase your 5-hour package** above with your credit card.
-2. **We set up a call**: once you've booked, we'll reach out to schedule a short call to discuss your goals and find lesson times that work for you.
-3. **Start learning** in La Jolla with your native Italian teacher, textbook included.
-4. **Continue at your pace**: when you finish your 5 hours, simply book another package and keep going.
-
----
-
-## Reschedule policy {#reschedule}
-
-Life happens. You can reschedule any lesson at no charge with at least **24 hours' notice**. Just let your teacher know in advance and we'll find a new time.
-
----
+1. Purchase your package above with your credit card.
+2. We reach out to set up a short call to discuss your goals and find times that work for you.
+3. Start learning in La Jolla. When your 5 hours are up, book another package to continue.
 
 ## Give the gift of Italian {#gift}
 
-Looking for a memorable present? A La Jolla lesson package makes a unique gift for the language lover, the traveler planning a trip to Italy, or anyone reconnecting with their heritage. Purchase a package above and [contact us](/contact) to have it set up as a gift, and we'll coordinate scheduling directly with the recipient.
-
----
+A La Jolla lesson package makes a memorable gift. Purchase one above and [contact us](/contact) to set it up as a gift, and we'll coordinate scheduling directly with the recipient.
 
 Questions? [Contact us](/contact). We're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -3,21 +3,23 @@ title: In-Person Italian Classes in La Jolla
 image: /img/positano-flag.jpg
 aliases:
     - /la-jolla
-subtitle: Premium private Italian lessons in a refined La Jolla office
+subtitle: Private Italian lessons for travel, citizenship, and personal enrichment in La Jolla
 ---
 
-Learn Italian in a polished, private setting on **Fay Avenue**, just steps from **The Lot La Jolla**. This is our premium in-person option for adults who want focused instruction, a comfortable professional environment, and a class built entirely around their goals.
+Learn Italian in a quiet professional office on **Fay Avenue**, just steps from **The Lot La Jolla**. This is our premium in-person option for adults who want individual attention, flexible pacing, and the convenience of learning in La Jolla.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your level, pace, and priorities. Come on your own for dedicated one-on-one work, or learn with one partner, friend, or colleague for a private two-person experience.
+No classroom group, no fixed curriculum, and no commute to Kearny Mesa. Every lesson is taught by a **native Italian teacher** and tailored to your level, pace, and priorities. Come on your own for dedicated one-on-one work, or learn with one partner, friend, or colleague for a private two-person experience.
 
-This format works especially well for students preparing for travel, reconnecting with family heritage, studying for citizenship, planning a move abroad, or learning Italian for professional reasons.
+This format works especially well for adults preparing for travel, reconnecting with family heritage, studying for citizenship, planning a move abroad, or learning Italian for professional reasons.
 
 Applying for **Italian citizenship**? We can prepare you for the **B1 language requirement**. [Learn more about Italian citizenship and the B1 exam]({{< relref "italian-citizenship-and-visa.md" >}}).
+
+If you want focused instruction in a polished La Jolla setting, start with a five-lesson package and we will shape the lessons around your goals.
 
 ## What's included {#included}
 
 - **Five private one-hour lessons** per package, with a weekly rhythm recommended for steady progress.
-- **Premium La Jolla setting** in a professional office on Fay Avenue, near The Lot La Jolla.
+- **Convenient La Jolla setting** in a professional office on Fay Avenue, near The Lot La Jolla.
 - **Current availability**: Wednesday and Friday evenings after 6 PM.
 - **One or two students**: choose dedicated individual instruction or a private pair format.
 - **Textbook included**, with nothing extra to buy.
@@ -49,6 +51,6 @@ Start with a five-lesson package. After the first package, you can continue with
 
 ## Give the gift of Italian {#gift}
 
-A premium La Jolla lesson package makes a thoughtful gift for a traveler, a professional, or anyone with a personal connection to Italy. Purchase one above and [contact us](/contact) to set it up as a gift, and we'll coordinate scheduling directly with the recipient.
+A La Jolla private lesson package makes a thoughtful gift for a traveler, a professional, or anyone with a personal connection to Italy. Purchase one above and [contact us](/contact) to set it up as a gift, and we'll coordinate scheduling directly with the recipient.
 
 Questions? [Contact us](/contact). We're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -20,19 +20,18 @@ Whatever brings you to Italian, we shape the lessons around it: a trip to Italy,
 
 ## Pricing {#pricing}
 
-We ask for a **5-hour commitment** to get started:
+Get started with a 5-hour package, and book more whenever you're ready to continue.
 
-| Students | 5-hour package |
-| :--- | :--- |
-| **1 person** | **$599** |
-| **2 people** | **$899** |
+**One student** &middot; $599 for 5 hours
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours for 1 person</a>
 </div>
 
+**Two students** &middot; $899 for 5 hours
+
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours for 2 people</a>
 </div>
 
 ## How it works {#how-it-works}

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -9,22 +9,22 @@ subtitle: Private Italian lessons in a prestigious La Jolla office, scheduled ar
 Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lessons take place in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and tailored to your level, goals, and pace. Schedule **weekdays from 2 PM onward, or anytime on weekends**.
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
 </div>
 
 ---
 
 ## Why Choose These Classes? {#why}
 
-- **Prestigious La Jolla location** — a professional office on Fay Ave, near The Lot La Jolla.
-- **Native Italian teacher** — all our instructors are native Italian speakers with experience teaching adults at every level.
-- **Flexible scheduling** — meet **weekdays from 2 PM onward, or anytime on weekends**. We build the schedule around you.
-- **One or two students** — learn solo, or split the lessons with a partner, friend, or colleague.
-- **Tailored to you** — from absolute beginner to advanced, every lesson is built around your goals.
+- **Prestigious La Jolla location**: a professional office on Fay Ave, near The Lot La Jolla.
+- **Native Italian teacher**: all our instructors are native Italian speakers with experience teaching adults at every level.
+- **Flexible scheduling**: meet **weekdays from 2 PM onward, or anytime on weekends**. We build the schedule around you.
+- **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
+- **Tailored to you**: from absolute beginner to advanced, every lesson is built around your goals.
 
 ---
 
@@ -38,11 +38,11 @@ We ask for a **5-hour commitment** to get started:
 | **2 people** | **$799** |
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
 </div>
 
 ---
@@ -50,7 +50,7 @@ We ask for a **5-hour commitment** to get started:
 ## How It Works {#how-it-works}
 
 1. **Purchase your 5-hour package** above with your credit card.
-2. **We contact you to schedule** — after your purchase, we'll reach out to arrange your lessons for any day and time that works for you.
+2. **We contact you to schedule**: after your purchase, we'll reach out to arrange your lessons for any day and time that works for you.
 3. **Start learning** in La Jolla with your native Italian teacher.
 
-Questions? [Contact us](/contact) — we're happy to help.
+Questions? [Contact us](/contact). We're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -10,6 +10,8 @@ Learn Italian one-on-one (or with a friend) in a prestigious office on **Fay Ave
 
 Whatever brings you to Italian, we shape the lessons around it: a trip to Italy, your family heritage, citizenship, a move abroad, or work.
 
+Applying for **Italian citizenship**? We can prepare you for the **B1 language requirement**. [Learn more about Italian citizenship and the B1 exam]({{< relref "italian-citizenship-and-visa.md" >}}).
+
 ## What's included {#included}
 
 - **Five one-hour lessons** per package. We recommend one lesson a week.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -48,6 +48,8 @@ Start with a five-lesson package. After the first package, you can continue with
   <p class="checkout-note">Each package includes five one-hour lessons. Textbook included.</p>
 </div>
 
+Prefer to organize private Italian lessons at your home or another La Jolla location? [Contact us](/contact) and we can discuss a tailored arrangement.
+
 ## How it works {#how-it-works}
 
 1. Purchase your package above with your credit card.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -3,27 +3,30 @@ title: In-Person Italian Classes in La Jolla
 image: /img/positano-flag.jpg
 aliases:
     - /la-jolla
-subtitle: Private Italian lessons in a prestigious La Jolla office, scheduled around you
+subtitle: Premium private Italian lessons in a refined La Jolla office
 ---
 
-Learn Italian one-on-one (or with a friend) in a prestigious office on **Fay Avenue**, just steps from **The Lot La Jolla**. Every lesson is taught by a **native Italian teacher** and built around your level, goals, and pace.
+Learn Italian in a polished, private setting on **Fay Avenue**, just steps from **The Lot La Jolla**. This is our premium in-person option for adults who want focused instruction, a comfortable professional environment, and a class built entirely around their goals.
 
-Whatever brings you to Italian, we shape the lessons around it: a trip to Italy, your family heritage, citizenship, a move abroad, or work.
+Every lesson is taught by a **native Italian teacher** and tailored to your level, pace, and priorities. Come on your own for dedicated one-on-one work, or learn with one partner, friend, or colleague for a private two-person experience.
+
+This format works especially well for students preparing for travel, reconnecting with family heritage, studying for citizenship, planning a move abroad, or learning Italian for professional reasons.
 
 Applying for **Italian citizenship**? We can prepare you for the **B1 language requirement**. [Learn more about Italian citizenship and the B1 exam]({{< relref "italian-citizenship-and-visa.md" >}}).
 
 ## What's included {#included}
 
-- **Five one-hour lessons** per package. We recommend one lesson a week.
+- **Five private one-hour lessons** per package, with a weekly rhythm recommended for steady progress.
+- **Premium La Jolla setting** in a professional office on Fay Avenue, near The Lot La Jolla.
 - **Current availability**: Wednesday and Friday evenings after 6 PM.
-- **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
+- **One or two students**: choose dedicated individual instruction or a private pair format.
 - **Textbook included**, with nothing extra to buy.
-- **All levels**, from beginner to advanced.
+- **Personalized curriculum** for all levels, from beginner to advanced.
 - **Free rescheduling** of any lesson with at least 24 hours' notice.
 
 ## Pricing {#pricing}
 
-Get started with a package of five one-hour lessons, and book more whenever you're ready to continue.
+Start with a five-lesson package. After the first package, you can continue with additional sessions as needed.
 
 **One student** &middot; $599 for five one-hour lessons
 
@@ -40,11 +43,12 @@ Get started with a package of five one-hour lessons, and book more whenever you'
 ## How it works {#how-it-works}
 
 1. Purchase your package above with your credit card.
-2. We reach out to set up a short call to discuss your goals and find times that work for you.
-3. Start learning in La Jolla. When you finish your five lessons, book another package to continue.
+2. We reach out to understand your goals, level, and scheduling preferences.
+3. Your teacher prepares lessons around your priorities, then you begin your private sessions in La Jolla.
+4. When you finish your five lessons, book another package to continue.
 
 ## Give the gift of Italian {#gift}
 
-A La Jolla lesson package makes a memorable gift. Purchase one above and [contact us](/contact) to set it up as a gift, and we'll coordinate scheduling directly with the recipient.
+A premium La Jolla lesson package makes a thoughtful gift for a traveler, a professional, or anyone with a personal connection to Italy. Purchase one above and [contact us](/contact) to set it up as a gift, and we'll coordinate scheduling directly with the recipient.
 
 Questions? [Contact us](/contact). We're happy to help.

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -15,10 +15,10 @@ Applying for **Italian citizenship**? We can prepare you for the **B1 language r
 ## What's included {#included}
 
 - **Five one-hour lessons** per package. We recommend one lesson a week.
-- **Flexible scheduling**: weekdays from 2 PM onward, or anytime on weekends.
+- **Current availability with Valentina**: Wednesday and Friday evenings after 6 PM, available through August 17, 2026.
 - **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
 - **Textbook included**, with nothing extra to buy.
-- **All levels**, from absolute beginner to advanced.
+- **All levels**, from beginner to advanced.
 - **Free rescheduling** of any lesson with at least 24 hours' notice.
 
 ## Pricing {#pricing}

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -13,7 +13,7 @@ Learn Italian one-on-one (or with a friend) in the heart of La Jolla. Our lesson
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
 </div>
 
 ---
@@ -35,14 +35,14 @@ We ask for a **5-hour commitment** to get started:
 | Students | 5-hour package |
 | :--- | :--- |
 | **1 person** | **$599** |
-| **2 people** | **$799** |
+| **2 people** | **$899** |
 
 <div class="tc">
 <a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
 </div>
 
 ---

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -30,16 +30,22 @@ If you want focused instruction in a polished La Jolla setting, start with a fiv
 
 Start with a five-lesson package. After the first package, you can continue with additional sessions as needed.
 
-**One student** &middot; $599 for five one-hour lessons
-
-<div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 lessons for 1 person</a>
-</div>
-
-**Two students** &middot; $899 for five one-hour lessons
-
-<div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 lessons for 2 people</a>
+<div class="checkout-options" aria-label="La Jolla lesson package options">
+  <form class="checkout-card" action="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" method="GET">
+    <button type="submit" class="checkout-button">
+      <span>One Student</span>
+      <strong>$599</strong>
+      <small>5 private lessons</small>
+    </button>
+  </form>
+  <form class="checkout-card" action="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" method="GET">
+    <button type="submit" class="checkout-button">
+      <span>Two Students</span>
+      <strong>$899</strong>
+      <small>5 private lessons</small>
+    </button>
+  </form>
+  <p class="checkout-note">Each package includes five one-hour lessons. Textbook included.</p>
 </div>
 
 ## How it works {#how-it-works}

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -12,6 +12,7 @@ Whatever brings you to Italian, we shape the lessons around it: a trip to Italy,
 
 ## What's included {#included}
 
+- **Five one-hour lessons** per package. We recommend one lesson a week.
 - **Flexible scheduling**: weekdays from 2 PM onward, or anytime on weekends.
 - **One or two students**: learn solo, or split the lessons with a partner, friend, or colleague.
 - **Textbook included**, with nothing extra to buy.
@@ -20,18 +21,18 @@ Whatever brings you to Italian, we shape the lessons around it: a trip to Italy,
 
 ## Pricing {#pricing}
 
-Get started with a 5-hour package, and book more whenever you're ready to continue.
+Get started with a package of five one-hour lessons, and book more whenever you're ready to continue.
 
-**One student** &middot; $599 for 5 hours
+**One student** &middot; $599 for five one-hour lessons
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours for 1 person</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 lessons for 1 person</a>
 </div>
 
-**Two students** &middot; $899 for 5 hours
+**Two students** &middot; $899 for five one-hour lessons
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours for 2 people</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 lessons for 2 people</a>
 </div>
 
 ## How it works {#how-it-works}

--- a/site/content/italian-in-person-classes-la-jolla.md
+++ b/site/content/italian-in-person-classes-la-jolla.md
@@ -20,7 +20,7 @@ Whatever brings you to Italian, we build the lessons around it: planning a trip 
 
 ---
 
-## Why Choose These Classes? {#why}
+## Why choose these classes? {#why}
 
 - **Prestigious La Jolla location**: a professional office on Fay Ave, near The Lot La Jolla.
 - **Native Italian teacher**: all our instructors are native Italian speakers with experience teaching adults at every level.
@@ -51,7 +51,7 @@ We ask for a **5-hour commitment** to get started:
 
 ---
 
-## How It Works {#how-it-works}
+## How it works {#how-it-works}
 
 1. **Purchase your 5-hour package** above with your credit card.
 2. **We set up a call**: once you've booked, we'll reach out to schedule a short call to discuss your goals and find lesson times that work for you.
@@ -60,13 +60,13 @@ We ask for a **5-hour commitment** to get started:
 
 ---
 
-## Reschedule Policy {#reschedule}
+## Reschedule policy {#reschedule}
 
 Life happens. You can reschedule any lesson at no charge with at least **24 hours' notice**. Just let your teacher know in advance and we'll find a new time.
 
 ---
 
-## Give the Gift of Italian {#gift}
+## Give the gift of Italian {#gift}
 
 Looking for a memorable present? A La Jolla lesson package makes a unique gift for the language lover, the traveler planning a trip to Italy, or anyone reconnecting with their heritage. Purchase a package above and [contact us](/contact) to have it set up as a gift, and we'll coordinate scheduling directly with the recipient.
 

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,0 +1,28 @@
+---
+title: New — In-Person Italian Classes in La Jolla
+date: 2026-06-11
+description: Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Any day, any time.
+---
+
+We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
+
+Every lesson is taught by a **native Italian teacher** and tailored to your level and goals. Schedule your lessons **weekdays from 2 PM onward, or anytime on weekends** — we build everything around you.
+
+## Pricing
+
+We ask for a **5-hour commitment** to get started:
+
+- **1 person:** $599 for 5 hours
+- **2 people:** $799 for 5 hours
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+</div>
+
+<div class="tc">
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+</div>
+
+After you purchase, we'll contact you to arrange your schedule.
+
+[Learn more about our La Jolla classes]({{< relref "italian-in-person-classes-la-jolla.md" >}})

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,14 +1,14 @@
 ---
 title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
-description: "Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Current availability: Wednesday and Friday evenings after 6 PM."
+description: "Premium private Italian lessons with a native Italian teacher in a refined La Jolla office on Fay Ave, near The Lot La Jolla. Current availability: Wednesday and Friday evenings after 6 PM."
 ---
 
-We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
+We're excited to announce our premium **in-person Italian classes in La Jolla**. Learn Italian one-on-one, or with one partner, in a refined professional office on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Current availability is **Wednesday and Friday evenings after 6 PM**, with free rescheduling of any lesson with 24 hours' notice.
+Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether you are preparing for travel, reconnecting with family heritage, studying for citizenship, or learning Italian for professional reasons. Textbook included. Current availability is **Wednesday and Friday evenings after 6 PM**, with free rescheduling of any lesson with 24 hours' notice.
 
-We offer 5-hour lesson packages for one or two students. After you sign up, we'll set up a quick call to discuss your goals and schedule. Packages also make a great gift.
+We offer five-hour private lesson packages for one or two students. After you sign up, we reach out to understand your goals, level, and schedule so the lessons can be prepared around you. Packages also make a thoughtful gift.
 
 <div class="tc">
 <a href='{{< relref "/italian-in-person-classes-la-jolla.md" >}}' class="btn raise">Learn more about our La Jolla classes</a>

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,12 +1,12 @@
 ---
 title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
-description: Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Weekdays from 2 PM, anytime on weekends.
+description: "Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Current availability with Valentina: Wednesday and Friday evenings after 6 PM."
 ---
 
 We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Schedule **weekdays from 2 PM onward, or anytime on weekends**, and reschedule any lesson with 24 hours' notice.
+Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Current availability with Valentina is **Wednesday and Friday evenings after 6 PM, through August 17, 2026**, with free rescheduling of any lesson with 24 hours' notice.
 
 We offer 5-hour lesson packages for one or two students. After you sign up, we'll set up a quick call to discuss your goals and schedule. Packages also make a great gift.
 

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -11,5 +11,5 @@ Every lesson is taught by a **native Italian teacher** and tailored to your goal
 We offer 5-hour lesson packages for one or two students. After you sign up, we'll set up a quick call to discuss your goals and schedule. Packages also make a great gift.
 
 <div class="tc">
-<a href='{{< relref "italian-in-person-classes-la-jolla.md" >}}' class="btn raise">Learn more about our La Jolla classes</a>
+<a href='{{< relref "/italian-in-person-classes-la-jolla.md" >}}' class="btn raise">Learn more about our La Jolla classes</a>
 </div>

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,7 +1,7 @@
 ---
 title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
-description: Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Any day, any time.
+description: Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Weekdays from 2 PM, anytime on weekends.
 ---
 
 We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -8,21 +8,8 @@ We're excited to announce **in-person Italian classes in La Jolla**! Learn Itali
 
 Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Schedule **weekdays from 2 PM onward, or anytime on weekends**, and reschedule any lesson with 24 hours' notice.
 
-## Pricing
-
-We ask for a **5-hour commitment** to get started:
-
-- **1 person:** $599 for 5 hours
-- **2 people:** $899 for 5 hours
+We offer 5-hour lesson packages for one or two students. After you sign up, we'll set up a quick call to discuss your goals and schedule. Packages also make a great gift.
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
+<a href='{{< relref "italian-in-person-classes-la-jolla.md" >}}' class="btn raise">Learn more about our La Jolla classes</a>
 </div>
-
-<div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
-</div>
-
-After you purchase, we'll set up a quick call to discuss your goals and schedule. When your 5 hours are up, just book another package to continue. Packages also make a great gift.
-
-[Learn more about our La Jolla classes]({{< relref "italian-in-person-classes-la-jolla.md" >}})

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -6,7 +6,7 @@ description: Private one-on-one Italian lessons with a native Italian teacher in
 
 We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your level and goals. Schedule your lessons **weekdays from 2 PM onward, or anytime on weekends**. We build everything around you.
+Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Schedule **weekdays from 2 PM onward, or anytime on weekends**, and reschedule any lesson with 24 hours' notice.
 
 ## Pricing
 
@@ -23,6 +23,6 @@ We ask for a **5-hour commitment** to get started:
 <a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
 </div>
 
-After you purchase, we'll contact you to arrange your schedule.
+After you purchase, we'll set up a quick call to discuss your goals and schedule. When your 5 hours are up, just book another package to continue. Packages also make a great gift.
 
 [Learn more about our La Jolla classes]({{< relref "italian-in-person-classes-la-jolla.md" >}})

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,12 +1,12 @@
 ---
 title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
-description: "Premium private Italian lessons with a native Italian teacher in a refined La Jolla office on Fay Ave, near The Lot La Jolla. Current availability: Wednesday and Friday evenings after 6 PM."
+description: "Private Italian lessons for travel, citizenship, and personal enrichment in a professional La Jolla office on Fay Ave, near The Lot La Jolla. Current availability: Wednesday and Friday evenings after 6 PM."
 ---
 
-We're excited to announce our premium **in-person Italian classes in La Jolla**. Learn Italian one-on-one, or with one partner, in a refined professional office on **Fay Avenue**, just steps from **The Lot La Jolla**.
+We're excited to announce our premium **in-person Italian classes in La Jolla**. Learn Italian one-on-one, or with one partner, in a quiet professional office on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether you are preparing for travel, reconnecting with family heritage, studying for citizenship, or learning Italian for professional reasons. Textbook included. Current availability is **Wednesday and Friday evenings after 6 PM**, with free rescheduling of any lesson with 24 hours' notice.
+Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether you are preparing for travel, reconnecting with family heritage, studying for citizenship, or learning Italian for professional reasons. No classroom group, no fixed curriculum, and no commute to Kearny Mesa. Textbook included. Current availability is **Wednesday and Friday evenings after 6 PM**, with free rescheduling of any lesson with 24 hours' notice.
 
 We offer five-hour private lesson packages for one or two students. After you sign up, we reach out to understand your goals, level, and schedule so the lessons can be prepared around you. Packages also make a thoughtful gift.
 

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,12 +1,12 @@
 ---
-title: New — In-Person Italian Classes in La Jolla
+title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
 description: Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Any day, any time.
 ---
 
 We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your level and goals. Schedule your lessons **weekdays from 2 PM onward, or anytime on weekends** — we build everything around you.
+Every lesson is taught by a **native Italian teacher** and tailored to your level and goals. Schedule your lessons **weekdays from 2 PM onward, or anytime on weekends**. We build everything around you.
 
 ## Pricing
 
@@ -16,11 +16,11 @@ We ask for a **5-hour commitment** to get started:
 - **2 people:** $799 for 5 hours
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours — 1 person ($599)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours — 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
 </div>
 
 After you purchase, we'll contact you to arrange your schedule.

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -1,12 +1,12 @@
 ---
 title: In-Person Italian Classes in La Jolla
 date: 2026-06-11
-description: "Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Current availability with Valentina: Wednesday and Friday evenings after 6 PM."
+description: "Private one-on-one Italian lessons with a native Italian teacher in a prestigious La Jolla office on Fay Ave, near The Lot La Jolla. Current availability: Wednesday and Friday evenings after 6 PM."
 ---
 
 We're excited to announce **in-person Italian classes in La Jolla**! Learn Italian one-on-one (or with a friend) in a prestigious office space on **Fay Avenue**, just steps from **The Lot La Jolla**.
 
-Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Current availability with Valentina is **Wednesday and Friday evenings after 6 PM, through August 17, 2026**, with free rescheduling of any lesson with 24 hours' notice.
+Every lesson is taught by a **native Italian teacher** and tailored to your goals, whether that's a trip to Italy, family heritage, citizenship, or work. Textbook included. Current availability is **Wednesday and Friday evenings after 6 PM**, with free rescheduling of any lesson with 24 hours' notice.
 
 We offer 5-hour lesson packages for one or two students. After you sign up, we'll set up a quick call to discuss your goals and schedule. Packages also make a great gift.
 

--- a/site/content/news/italian-in-person-classes-la-jolla.md
+++ b/site/content/news/italian-in-person-classes-la-jolla.md
@@ -13,14 +13,14 @@ Every lesson is taught by a **native Italian teacher** and tailored to your leve
 We ask for a **5-hour commitment** to get started:
 
 - **1 person:** $599 for 5 hours
-- **2 people:** $799 for 5 hours
+- **2 people:** $899 for 5 hours
 
 <div class="tc">
 <a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-1-person-5-hours/R3QJ6H3XBNPRFXALQS6MRRA7" class="btn raise">Purchase 5 hours, 1 person ($599)</a>
 </div>
 
 <div class="tc">
-<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($799)</a>
+<a href="https://italianschoolsd.square.site/product/in-person-italian-classes-la-jolla-2-people-5-hours/CBEN6APPV2A75VQBXS7QRWQS" class="btn raise">Purchase 5 hours, 2 people ($899)</a>
 </div>
 
 After you purchase, we'll contact you to arrange your schedule.

--- a/site/layouts/partials/contact-form.html
+++ b/site/layouts/partials/contact-form.html
@@ -20,6 +20,26 @@
       </div>
     </div>
 
+    <div class="flex-l mhn1-l">
+      <!-- Phone -->
+      <div class="ph1-l w-50-l">
+        <fieldset>
+          <input type="tel" id="phone" name="phone" placeholder="Phone" class="w-100 mb2">
+          <label for="phone">Phone</label>
+        </fieldset>
+      </div>
+      <!-- Preferred contact method -->
+      <div class="ph1-l w-50-l">
+        <fieldset class="contact-select-field">
+          <label for="preferred-contact" class="contact-select-label">Preferred contact method</label>
+          <select id="preferred-contact" name="preferred_contact" class="w-100 mb2">
+            <option value="email">Email</option>
+            <option value="phone">Phone</option>
+          </select>
+        </fieldset>
+      </div>
+    </div>
+
     <!-- Message -->
     <fieldset>
       <textarea id="message" name="message" placeholder="Your message" rows="8" cols="80" class="w-100"></textarea>


### PR DESCRIPTION
## Summary
Adds a new private-lesson offering: **In-Person Italian Classes in La Jolla**, taught by a native Italian teacher in a prestigious office on Fay Ave, near The Lot La Jolla.

- **New page** `italian-in-person-classes-la-jolla.md` (alias `/la-jolla`) — overview, pricing, scheduling (weekdays from 2 PM onward, anytime on weekends), and Square purchase buttons.
- **New news item** announcing the offering.
- **/adults** — short mention under Private & Custom Classes (no price/schedule, links to the dedicated page).

## Square
Two live catalog items created (Classes category), 5-hour packages:
- 1 person — $599
- 2 people — $799

Checkout links verified returning HTTP 200 with correct product titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)