### PR TITLE
AP Italian private prep

### DIFF
--- a/site/content/accredited-classes.md
+++ b/site/content/accredited-classes.md
@@ -24,14 +24,14 @@ We offer two tracks: **Italian as a Foreign Language** (for new learners) and **
 For students new to Italian. Lessons use a conversation-first approach focused on real conversation and everyday situations, building speaking confidence alongside grammar, vocabulary, reading, and writing.
 
 * **Italian 5-6:** Wednesdays, **4:00-6:00pm**, in person. First class: **August 19, 2026**.
-* **Italian 1-2** (*for beginners*)**, 3-4, and 7-8 & AP Preparation:** flexible schedule, arranged with enrolled students (online or in-person). *[See AP Italian page](/ap-italian-san-diego) for 7-8 & AP.*
+* **Italian 1-2** (*for beginners*)**, 3-4, and 7-8 & AP Preparation:** flexible schedule, arranged with enrolled students (online or in-person). *[See AP Italian page](/ap-italian-san-diego) for 7-8 & AP and [Private AP Preparation]({{< ref "private-ap-italian-prep.md" >}}).*
 
 ### Italian for Italian Speakers {#italian-speakers}
 
 For heritage speakers who are already fluent. As they progress, students follow the literature program taught in Italian high schools, reading and discussing Dante's *Divina Commedia*, Boccaccio's *Decameron*, Manzoni's *I Promessi Sposi*, and Homer's *Iliad* and *Odyssey*, alongside grammar, composition, and culture.
 
 * **Italian 1-2, 3-4, and 5-6:** Thursdays, **4:15-6:15pm**, in person. First class: **August 20, 2026**. *(Classes are divided by level.)*
-* **Italian 7-8 & AP Preparation:** flexible schedule, arranged with enrolled students (online or in-person). *[See AP Italian page](/ap-italian-san-diego).*
+* **Italian 7-8 & AP Preparation:** flexible schedule, arranged with enrolled students (online or in-person). *[See AP Italian page](/ap-italian-san-diego) and [Private AP Preparation]({{< ref "private-ap-italian-prep.md" >}}).*
 
 Students with prior Italian study may test into a higher level than 1-2. Please indicate this on the pre-enrollment form or contact us in advance. *(Note: Direct enrollment into levels above 1-2 requires a [curriculum alignment fee](/enroll-accredited#alignment-fee).)* Note: if a student enrolls in, for example, Italian 5-6 during high school, they will receive three years of foreign language credit. Credit is tied to the class level, not the number of years attended.
 

--- a/site/content/ap-italian-san-diego.md
+++ b/site/content/ap-italian-san-diego.md
@@ -25,3 +25,11 @@ Italian school of San Diego students which have reached year 4 of the [accredite
 It is important to stress that it is the cumulative instructions from the 4 levels
 of Italian classes that prepare the students for the AP test, many topics useful
 for the AP test are covered in Italian 1-2, Italian 3-4 and Italian 5-6.
+
+## Private Tutoring and Dedicated Preparation {#private-prep}
+
+For students who need a more personalized approach or want to focus specifically on the exam's technical expectations, we offer **private, one-on-one preparation sessions** with our School Director.
+
+These sessions are available both online and in person and are specifically designed to address the challenges of the AP Italian exam, including the new digital format and Course Project requirements.
+
+* [Learn more about Private AP Italian Preparation]({{< ref "private-ap-italian-prep.md" >}})

--- a/site/content/private-ap-italian-prep.md
+++ b/site/content/private-ap-italian-prep.md
@@ -1,0 +1,44 @@
+---
+title: Private AP Italian Tutoring & Exam Preparation
+image: /img/milan.jpg
+subtitle: One-on-one sessions with our School Director, online or in San Diego
+---
+
+## Why Specialized AP Italian Preparation? {#why-specialized-prep}
+
+Achieving a high score (4 or 5) on the AP Italian Language and Culture exam requires more than just language proficiency. Whether you are a heritage speaker already fluent in Italian or a student who has studied the language for several years, the exam has **very specific expectations** and precise types of responses that require dedicated training.
+
+Starting from the **2026-2027 school year**, the AP Italian exam is also undergoing a **major redesign**, transitioning to a fully digital format and introducing new components like the Course Project.
+
+### Key Challenges of the AP Exam {#challenges}
+
+*   **Precise Expectations:** The College Board looks for specific markers in listening, reading, writing, and speaking. Without proper preparation, even fluent speakers risk a lower score if they don't follow the required rubrics.
+*   **Time Management:** The exam is fast-paced. Knowing how to synthesize information from multiple sources (articles, charts, and audio) under pressure is a skill in itself.
+*   **New Digital Format:** Navigating the digital exam interface and mastering tasks like the spontaneous Q&A for the Course Project requires practice.
+*   **Cultural Context:** The exam measures your ability to make cultural comparisons and understand Italian products, practices, and perspectives.
+
+## Our Private Preparation Program {#program}
+
+We offer **private, one-on-one sessions** tailored to the student's specific needs. These sessions can be held **online via Zoom** or **in person** at our [San Diego location](/location).
+
+### Instruction by our School Director {#instructor}
+
+All private AP preparation is led by **Maura D’Andrea**, the Director of the Italian School of San Diego. Maura holds a Master’s degree in Education from Università Cattolica del Sacro Cuore (Milan) and a postgraduate specialization in “Didactics and Promotion of Italian Language and Culture to Foreigners” from Università Ca’ Foscari Venezia. Her expertise ensures that students receive high-level, pedagogical guidance specifically targeted at the AP exam's requirements.
+
+### What We Cover {#what-we-cover}
+
+*   **Personalized Assessment:** We start with an evaluation of the student's current level and identify specific areas for improvement.
+*   **Authentic Materials:** We use real Italian content (news, podcasts, literature) to build the interpretive skills measured by the exam.
+*   **Exam Simulations:** Practice with real AP tasks, including the new Course Project presentation and Q&A.
+*   **Individualized Feedback:** Detailed corrections and strategies for the Argumentative Essay, Email Reply, and speaking tasks.
+*   **Course Project Support:** Guidance on research, developing the presentation, and preparing the "Personalized Project Reference" (PPR).
+
+## Contact Us for a Consultation {#contact}
+
+Because every student's path to the AP exam is unique, we do not have a one-size-fits-all price for private tutoring. We invite you to contact us to discuss your goals, schedule, and specific needs.
+
+<div class="tc">
+  <a href="/contact" class="btn raise">Contact us for AP Italian Private Prep</a>
+</div>
+
+Whether you are aiming to earn college credit or simply want to master the Italian language at a high level, we are here to help you succeed!


### PR DESCRIPTION
## Summary
Created a new page for private AP Italian preparation and added links to it from other AP-related pages.

### Changes:
- Added `site/content/private-ap-italian-prep.md`: A new page highlighting the importance of specialized test prep (especially for the 2027 redesign) and offering one-on-one sessions with the School Director.
- Updated `site/content/ap-italian-san-diego.md`: Added a section linking to the private preparation page.
- Updated `site/content/accredited-classes.md`: Added links to the private preparation option in the course lists.

### Trello Card:
[AP Italian private prep](https://trello.com/c/25TuuHys/580-ap-italian-private-prep)
