### PR TITLE
Add Fall 2026 Adult Italian Schedule and Square Payment Links

### DIFF
--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -44,11 +44,11 @@ Start your Italian journey with our friendly, hands-on beginner classes! In this
 
 <div class="tc"><a href='{{< relref "news/adult-beginner-classes-fall-2026.md" >}}' class="btn raise">View Fall Beginner schedule & tuition</a></div>
 
-### Intermediate & Beginner-Intermediate {#intermediate}
+### Intermediate & Intermediate-Advanced {#intermediate}
 
-For students with at least some prior study who want to expand their grammar, vocabulary, and conversational agility. We offer multiple tracks (in-person on Monday, Tuesday, or Thursday, and online on Monday or Tuesday) to help you find the perfect match for your current level and schedule.
+For students with at least some prior study who want to expand their grammar, vocabulary, and conversational agility. We offer multiple tracks — including a dedicated Intermediate-Advanced section — in person on Monday, Tuesday, or Thursday, and online on Monday or Tuesday.
 
-<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-fall-2026.md" >}}' class="btn raise">View Fall Intermediate schedules & tuition</a></div>
+<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-fall-2026.md" >}}' class="btn raise">View Fall Intermediate & Int-Advanced schedules & tuition</a></div>
 
 ### Advanced & Conversation {#advanced}
 

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -16,104 +16,98 @@ Note: All in-person adult classes meet at our school at [4550 Kearny Villa Rd Su
 
 ---
 
-## Italian for Travelers {#travelers}
+## Fall 2026 Group Classes {#fall-2026}
 
-Planning a trip to Italy? Get ready with our "Italian for Travelers" program! We are launching two separate sessions for June and July 2026.
-
-<div class="tc">
-<a href="{{< relref "news/italian-for-travelers-june-july-2026.md" >}}" class="btn raise">Learn more and enroll to "Italian for travelers"</a>
-</div>
-
----
-
-## Summer 2026 Group Classes {#summer-2026}
-
-Our summer session runs for **10 weeks** from **June 1st to August 12th**.
+Our Fall session runs for **16 weeks** (15 weeks for Saturday classes) from **August 17th to December 19th, 2026**. We offer both in-person classes in Kearny Mesa and online virtual classes via Zoom. All of our instructors are native Italian speakers (mother tongue).
 
 ## Detailed Weekly Schedule (All classes 1.5 hours)
 
 | DAY | LEVEL | TEACHER | Time |
 | :--- | :--- | :--- | :--- |
-| **MONDAY** | **Int-Adv** | **Laura** | 6:00 PM - 7:30 PM |
-| **MONDAY** | **Intermediate** | **Sara** | 6:00 PM - 7:30 PM |
-| **MONDAY (Online)** | **Beginner** | **Tania Adami** | 6:00 PM - 7:30 PM |
-| **TUESDAY** | **Beg-Int** | **Valentina** | **6:00 PM - 7:30 PM** |
-| **TUESDAY (Online)** | **Beg-Int** | **Tania Adami** | 6:00 PM - 7:30 PM (9 classes, no June 30) |
-| **THURSDAY** | **Beginner** | **Valentina** | 6:00 PM - 7:30 PM |
+| **MONDAY** | **Intermediate** | **TBD** | 6:00 PM - 7:30 PM |
+| **MONDAY** | **Intermediate-Advanced** | **TBD** | 6:00 PM - 7:30 PM |
+| **MONDAY** | **Advanced** | **TBD** | 6:00 PM - 7:30 PM |
+| **MONDAY (Online)** | **Beg-Int** | **Tania Adami** | 6:00 PM - 7:30 PM |
+| **TUESDAY** | **Beg-Int** | **TBD** | 5:30 PM - 7:00 PM |
+| **TUESDAY (Online)** | **Intermediate** | **Tania Adami** | 6:00 PM - 7:30 PM |
+| **THURSDAY** | **Beginner** | **TBD** | 6:30 PM - 8:00 PM |
+| **THURSDAY** | **Beg-Int** | **TBD** | 6:30 PM - 8:00 PM |
+| **THURSDAY** | **Conversation** | **TBD** | 6:30 PM - 8:00 PM |
+| **THURSDAY (Online)** | **Beginner** | **Tania Adami** | 6:00 PM - 7:30 PM |
+| **SATURDAY** | **Beginner** | **TBD** | 10:00 AM - 11:30 AM (15 classes) |
 
-Choose your level below and enroll online with your credit card.
+Choose your level below to view schedule details, holidays, and enroll online.
 
-### Beginner class {#beginner}
+### Beginner Classes {#beginner}
 
-No prior Italian experience required.
+Start your Italian journey with our friendly, hands-on beginner classes! In this session, you'll build a solid foundation in Italian conversation, vocabulary, grammar, and culture—perfect for travel, family connection, or personal enrichment. No prior experience is required. We offer in-person sections (Thursday evening or Saturday morning) and an online section (Thursday evening).
 
-Start your Italian journey with our friendly, hands-on beginner class! In 10 weeks, you'll build a solid foundation in Italian conversation, vocabulary, and culture—perfect for travel, work, or connecting with family. We offer both in-person and online Zoom sessions.
+<div class="tc"><a href='{{< relref "news/adult-beginner-classes-fall-2026.md" >}}' class="btn raise">View Fall Beginner schedule & tuition</a></div>
 
-<div class="tc"><a href='{{< relref "news/adult-beginner-classes-summer-2026.md" >}}' class="btn raise">View summer beginner schedule & tuition</a></div>
+### Intermediate & Beginner-Intermediate {#intermediate}
 
-### Intermediate & Intermediate-Advanced {#intermediate}
+For students with at least some prior study who want to expand their grammar, vocabulary, and conversational agility. We offer multiple tracks (in-person on Monday, Tuesday, or Thursday, and online on Monday or Tuesday) to help you find the perfect match for your current level and schedule.
 
-For students with at least one year of Italian classes or equivalent self-study.
-
-We offer multiple tracks to keep you challenged and progressing, including **in-person and online Zoom sessions**, and a combined **Evaluation Day on June 1st** for our Monday students.
-
-<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-summer-2026.md" >}}' class="btn raise">View summer intermediate schedules & tuition</a></div>
+<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-fall-2026.md" >}}' class="btn raise">View Fall Intermediate schedules & tuition</a></div>
 
 ### Advanced & Conversation {#advanced}
 
-Advanced and Conversation classes will resume in the Fall. In the meantime, advanced students are welcome to join our Intermediate-Advanced class.
+Designed for students who can already hold conversations in Italian and want to refine their fluency, master advanced grammar structures, and discuss Italian literature, news, and culture in a collaborative setting.
 
-<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-summer-2026.md" >}}' class="btn raise">View summer Intermediate-Advanced schedule & tuition</a></div>
+<div class="tc"><a href='{{< relref "news/adult-advanced-classes-fall-2026.md" >}}' class="btn raise">View Fall Advanced & Conversation schedule & tuition</a></div>
 
 ## Private & Custom Classes {#private-custom}
 
 ### Private Lessons (In-person or via Zoom) {#private}
 
-One-on-one lessons tailored to your level and interests, from absolute beginner to advanced. All our instructors are experienced, native Italian speakers. Enjoy flexible scheduling and a 24-hour cancellation policy.
+One-on-one lessons tailored to your specific goals and pace. Enjoy flexible scheduling, custom curriculum design, and a 24-hour cancellation policy. All levels are welcome, from absolute beginner to advanced.
 
 <div class="tc"><a href='{{< relref "italian-private-classes.md" >}}' class="btn raise">Learn more about private lessons</a></div>
 
 ### Italian On Demand (Flexible Online Private Lessons) {#on-demand}
 
-Need more flexibility? Book a private one-hour lesson online via Zoom with as little as 12 hours' notice. No long-term commitment—just pay for one class at a time when it fits your schedule.
+Need ultimate flexibility? Book virtual private lessons online via Zoom with as little as 12 hours' notice. Pay per session when it fits your schedule, without any long-term commitment. **Note: Italian On Demand is online only.**
 
 <div class="tc"><a href='{{< relref "italian-on-demand.md" >}}' class="btn raise">Learn more about Italian On Demand</a></div>
 
 ### Italian for Businesses {#business}
 
-Custom Italian language training for your team — in person in San Diego or online via Zoom. All levels, industry-specific content, and flexible scheduling.
+Custom language and cultural training for your team, delivered in person in San Diego or online via Zoom. We adapt our content to fit your specific industry needs.
 
 <div class="tc"><a href='{{< relref "italian-private-classes-business-san-diego.md" >}}' class="btn raise">Learn more about corporate Italian training</a></div>
 
 ### Custom Group Classes {#custom-group}
 
-Have a group of 5+ friends or colleagues interested in learning Italian together?
-We offer custom classes online, at our location, or even at your home. [Contact us!](/contact) to discuss your needs.
+Interested in learning Italian with a group of friends, family members, or colleagues? We can set up custom group sessions online, at our facility, or at your preferred location. [Contact us!](/contact) to discuss details.
 
 ---
 
 ## Previous Sessions {#previous-sessions}
 
+- [Summer 2026]( {{< ref "news/adult-beginner-classes-summer-2026.md" >}} )
 - [January-May 2026]( {{< ref "news/adult-beginner-classes-january-may-2026.md" >}} )
 - [Fall 2025]( {{< ref "news/italian-adult-classes-fall-2025.md" >}} )
-- [Summer 2025 session]( {{< ref "news/italian-adult-classes-summer-2025.md" >}} )
 
 ---
 
-## Policies & Discounts {#policies}
+## Policies, Discounts, and Payment Plans {#policies}
 
 ### Enrollment & Confirmation {#enrollment-confirmation}
 
-Classes are scheduled and confirmed once enough enrollments are received. If a class does not meet the minimum, we’ll offer to transfer you to another class or provide a full refund.
+Classes are confirmed once they meet the minimum required enrollment. If a class is canceled due to low enrollment, we will offer to transfer you to another section or issue a full refund.
 
-### Cancellation Policy {#cancellation}
+### Payment Plans (Installments) {#payment-plans}
+
+We offer convenient monthly payment plans consisting of **5 payments** for all our adult classes (via credit card subscription). Please note that these plans are **not monthly enrollments**—the commitment is still for the entire duration of the course (15 or 16 classes). If you enroll using a payment plan, you are committing to completing all 5 monthly payments.
+
+### Cancellation & Refund Policy {#cancellation}
 
 - Full refund if you cancel at least 15 days before the first class.
-- 50% refund if you cancel before the 2nd class.
-- No refunds after the 2nd class.
+- 50% refund if you cancel after the first class but before the second class.
+- No refunds will be issued after the start of the second class.
 
-To request a refund, email `admin` at our domain `italianschoolsd.com`.
+To request a cancellation and refund, please email `admin` at our domain `italianschoolsd.com`.
 
 ### Family Discount {#family-discount}
 
-- 10% off for all additional family members (applied automatically at checkout).
+- 10% discount for all additional family members enrolling together (applied automatically at checkout).

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -13,21 +13,6 @@ For other levels, please see our [Adult classes overview]({{< relref "adults.md"
 
 ---
 
-## Monday Intermediate-Advanced (In person) {#mon-int-adv}
-
-Deepen your comprehension and expression skills in person.
-
-- **Teacher:** TBD
-- **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
-- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
-- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
-- **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
-
-<div class="tc"><a href='https://italianschoolsd.square.site/product/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/XJGbZFpy' class="btn raise">5 Monthly Payments of $126.72</a></div>
-
----
-
 ## Monday Advanced (In person) {#mon-adv}
 
 For students who want to master Italian fluency, syntax, and cultural idioms.

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -23,7 +23,7 @@ For students who want to master Italian fluency, syntax, and cultural idioms.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/MSMLQ47EKE7GGSPU627R2WNV' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-advanced-monday/MSMLQ47EKE7GGSPU627R2WNV' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/cvuA1Q5d' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ A conversation-heavy class focused on current topics, literature, and news.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** No textbook required — class materials are provided by the teacher.
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/GFEXH5UD5Z4ZZWZKUO3YIF4V' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-conversation-thursday/GFEXH5UD5Z4ZZWZKUO3YIF4V' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/KyqAr4HE' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -1,0 +1,64 @@
+---
+title: "Advanced & Conversation Adult Italian Classes: Fall 2026"
+date: 2026-06-28
+description: Schedule and tuition details for advanced-level and conversation adult Italian classes offered in person August through December 2026.
+---
+
+Take your Italian to the next level with our advanced and conversation classes! These sections are designed for students who can already hold conversations in Italian and want to refine their fluency, master complex grammatical structures, and discuss Italian culture, literature, and news.
+
+Our Fall session runs for **16 weeks** from **the week of August 17th to December 19th, 2026**.
+
+For other levels, please see our [Adult classes overview]({{< relref "adults.md" >}}), where you will find policies, discounts, and payment plan information.
+
+---
+
+## Monday Intermediate-Advanced (In person) {#mon-int-adv}
+
+Deepen your comprehension and expression skills in person.
+
+- **Teacher:** TBD
+- **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
+- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/5BTXMJPCYI3OUY6PZ4YCUIXR' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/5RwRRxk6' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Monday Advanced (In person) {#mon-adv}
+
+For students who want to master Italian fluency, syntax, and cultural idioms.
+
+- **Teacher:** TBD
+- **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
+- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/B6K2MUKZE2FM34N5KZQEQVIS' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/SqD8oz3t' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Thursday Conversation (In person) {#thu-conv}
+
+A conversation-heavy class focused on current topics, literature, and news.
+
+- **Teacher:** TBD
+- **Schedule:** Thursdays, 6:30 PM – 8:00 PM, August 20 – December 10, 2026 (16 classes)
+- **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/Q4WL53JZBURRX2GC56LT7FJO' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/hu9NiyaI' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+### Policies & Discounts
+
+- **Family Discount:** 10% off for all additional family members enrolling together (applied automatically at checkout).
+- **Payment Plan Commitment:** Choosing a payment plan is a commitment to the entire duration of the class. It is not a monthly subscription that can be canceled mid-session.
+- **Refunds:** Full refund if canceled 15 days before the first class; 50% refund before the second class; no refunds after the second class.
+
+Questions? [Contact us]({{< relref "contact.md" >}}) and we'll be happy to help!

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -23,7 +23,7 @@ For students who want to master Italian fluency, syntax, and cultural idioms.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-advanced-monday/MSMLQ47EKE7GGSPU627R2WNV' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-advanced-monday/MSMLQ47EKE7GGSPU627R2WNV?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/cvuA1Q5d' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ A conversation-heavy class focused on current topics, literature, and news.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** No textbook required — class materials are provided by the teacher.
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-conversation-thursday/GFEXH5UD5Z4ZZWZKUO3YIF4V' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-conversation-thursday/GFEXH5UD5Z4ZZWZKUO3YIF4V?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/KyqAr4HE' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -36,6 +36,7 @@ For students who want to master Italian fluency, syntax, and cultural idioms.
 - **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
 - **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/MSMLQ47EKE7GGSPU627R2WNV' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/cvuA1Q5d' class="btn raise">5 Monthly Payments of $126.72</a></div>
@@ -50,6 +51,7 @@ A conversation-heavy class focused on current topics, literature, and news.
 - **Schedule:** Thursdays, 6:30 PM – 8:00 PM, August 20 – December 10, 2026 (16 classes)
 - **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** No textbook required — class materials are provided by the teacher.
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/GFEXH5UD5Z4ZZWZKUO3YIF4V' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/KyqAr4HE' class="btn raise">5 Monthly Payments of $126.72</a></div>

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -1,6 +1,7 @@
 ---
 title: "Advanced & Conversation Adult Italian Classes: Fall 2026"
 date: 2026-06-28
+weight: 3
 description: Schedule and tuition details for advanced-level and conversation adult Italian classes offered in person August through December 2026.
 ---
 

--- a/site/content/news/adult-advanced-classes-fall-2026.md
+++ b/site/content/news/adult-advanced-classes-fall-2026.md
@@ -23,8 +23,8 @@ Deepen your comprehension and expression skills in person.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/5BTXMJPCYI3OUY6PZ4YCUIXR' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/5RwRRxk6' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/XJGbZFpy' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -37,8 +37,8 @@ For students who want to master Italian fluency, syntax, and cultural idioms.
 - **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/B6K2MUKZE2FM34N5KZQEQVIS' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/SqD8oz3t' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/MSMLQ47EKE7GGSPU627R2WNV' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/cvuA1Q5d' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -51,8 +51,8 @@ A conversation-heavy class focused on current topics, literature, and news.
 - **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/Q4WL53JZBURRX2GC56LT7FJO' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/hu9NiyaI' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/GFEXH5UD5Z4ZZWZKUO3YIF4V' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/KyqAr4HE' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -1,0 +1,66 @@
+---
+title: "Beginner Adult Italian Classes: Fall 2026"
+date: 2026-06-28
+description: Full schedule, tuition, and enrollment links for beginner-level adult Italian classes running August through December 2026.
+---
+
+Start your Italian language journey with our supportive and interactive beginner classes! These sections are designed for students with no prior Italian experience, focusing on practical conversation, vocabulary, and core grammar. Learn from native Italian speakers in a friendly, low-pressure environment.
+
+Our Fall session runs for **16 weeks** (15 weeks for Saturday classes) from **the week of August 17th to December 19th, 2026**.
+
+For other levels, please see our [Adult classes overview]({{< relref "adults.md" >}}), where you will find policies, discounts, and payment plan information.
+
+---
+
+## Thursday Beginner (In person) {#thu-beg}
+
+Enjoy the classroom experience and learn in person at our Kearny Mesa facility.
+
+- **Teacher:** TBD
+- **Schedule:** Thursdays, 6:30 PM – 8:00 PM, August 20 – December 10, 2026 (16 classes)
+- **Holidays (No Class):** November 26 (Thanksgiving), December 17 (Pre-winter break skip)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/E7URS2Q3P55X7JT6WZVFQZXX' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/fiGWy7FF' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Saturday Beginner (In person) {#sat-beg}
+
+Weekend section for those looking to start their Italian journey in person on Saturdays.
+
+- **Teacher:** TBD
+- **Schedule:** Saturdays, 10:00 AM – 11:30 AM, August 22 – December 12, 2026 (15 classes)
+- **Holidays (No Class):** September 5 (Labor Day Weekend), November 28 (Thanksgiving Weekend), December 19 (Pre-winter break skip)
+- **Tuition:** $540 for the full session (or 5 monthly payments of $118.80)
+- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/BVIR4IXALTMWUXHQRHSLZ745' class="btn raise">Pay in Full ($540)</a></div>
+<div class="tc"><a href='https://square.link/u/qetQriN2' class="btn raise">5 Monthly Payments of $118.80</a></div>
+
+---
+
+## Thursday Beginner (Online) {#thu-beg-online}
+
+Learn Italian via Zoom from the comfort of your home with **Tania**.
+
+- **Teacher:** Tania Adami
+- **Schedule:** Thursdays, 6:00 PM – 7:30 PM PST, August 20 – December 10, 2026 (16 classes)
+- **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
+- **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/FDLIIQOSM354P3FQRL7OHEVN' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/VjVHjchu' class="btn raise">5 Monthly Payments of $119.68</a></div>
+
+---
+
+### Policies & Discounts
+
+- **Family Discount:** 10% off for all additional family members enrolling together (applied automatically at checkout).
+- **Payment Plan Commitment:** Choosing a payment plan is a commitment to the entire duration of the class. It is not a monthly subscription that can be canceled mid-session.
+- **Refunds:** Full refund if canceled 15 days before the first class; 50% refund before the second class; no refunds after the second class.
+
+Questions? [Contact us]({{< relref "contact.md" >}}) and we'll be happy to help!

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -23,7 +23,7 @@ Enjoy the classroom experience and learn in person at our Kearny Mesa facility.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/QO6IEA6FHPS5I7R2HTWGRUYC' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday/QO6IEA6FHPS5I7R2HTWGRUYC' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/Cj77PKK0' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ Weekend section for those looking to start their Italian journey in person on Sa
 - **Tuition:** $540 for the full session (or 5 monthly payments of $118.80)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/WCHSFNTH2BALIWGEIXS5IBEH' class="btn raise">Pay in Full ($540)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-saturday/WCHSFNTH2BALIWGEIXS5IBEH' class="btn raise">Pay in Full ($540)</a></div>
 <div class="tc"><a href='https://square.link/u/AcNfjkG4' class="btn raise">5 Monthly Payments of $118.80</a></div>
 
 ---
@@ -53,7 +53,7 @@ Learn Italian via Zoom from the comfort of your home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/F2G667EDMNL6VHRRTDGTZYNI' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday-online/F2G667EDMNL6VHRRTDGTZYNI' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/1H7kAbQh' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -51,7 +51,7 @@ Learn Italian via Zoom from the comfort of your home with **Tania**.
 - **Schedule:** Thursdays, 6:00 PM – 7:30 PM PST, August 20 – December 10, 2026 (16 classes)
 - **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
-- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/F2G667EDMNL6VHRRTDGTZYNI' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/1H7kAbQh' class="btn raise">5 Monthly Payments of $119.68</a></div>

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -23,7 +23,7 @@ Enjoy the classroom experience and learn in person at our Kearny Mesa facility.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday/QO6IEA6FHPS5I7R2HTWGRUYC' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday/QO6IEA6FHPS5I7R2HTWGRUYC?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/Cj77PKK0' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ Weekend section for those looking to start their Italian journey in person on Sa
 - **Tuition:** $540 for the full session (or 5 monthly payments of $118.80)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-saturday/WCHSFNTH2BALIWGEIXS5IBEH' class="btn raise">Pay in Full ($540)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-saturday/WCHSFNTH2BALIWGEIXS5IBEH?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($540)</a></div>
 <div class="tc"><a href='https://square.link/u/AcNfjkG4' class="btn raise">5 Monthly Payments of $118.80</a></div>
 
 ---
@@ -53,7 +53,7 @@ Learn Italian via Zoom from the comfort of your home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday-online/F2G667EDMNL6VHRRTDGTZYNI' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beginner-thursday-online/F2G667EDMNL6VHRRTDGTZYNI?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/1H7kAbQh' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -1,6 +1,7 @@
 ---
 title: "Beginner Adult Italian Classes: Fall 2026"
 date: 2026-06-28
+weight: 1
 description: Full schedule, tuition, and enrollment links for beginner-level adult Italian classes running August through December 2026.
 ---
 

--- a/site/content/news/adult-beginner-classes-fall-2026.md
+++ b/site/content/news/adult-beginner-classes-fall-2026.md
@@ -23,8 +23,8 @@ Enjoy the classroom experience and learn in person at our Kearny Mesa facility.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/E7URS2Q3P55X7JT6WZVFQZXX' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/fiGWy7FF' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/QO6IEA6FHPS5I7R2HTWGRUYC' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/Cj77PKK0' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -38,8 +38,8 @@ Weekend section for those looking to start their Italian journey in person on Sa
 - **Tuition:** $540 for the full session (or 5 monthly payments of $118.80)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/BVIR4IXALTMWUXHQRHSLZ745' class="btn raise">Pay in Full ($540)</a></div>
-<div class="tc"><a href='https://square.link/u/qetQriN2' class="btn raise">5 Monthly Payments of $118.80</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/WCHSFNTH2BALIWGEIXS5IBEH' class="btn raise">Pay in Full ($540)</a></div>
+<div class="tc"><a href='https://square.link/u/AcNfjkG4' class="btn raise">5 Monthly Payments of $118.80</a></div>
 
 ---
 
@@ -53,8 +53,8 @@ Learn Italian via Zoom from the comfort of your home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/FDLIIQOSM354P3FQRL7OHEVN' class="btn raise">Pay in Full ($544)</a></div>
-<div class="tc"><a href='https://square.link/u/VjVHjchu' class="btn raise">5 Monthly Payments of $119.68</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/F2G667EDMNL6VHRRTDGTZYNI' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/1H7kAbQh' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---
 

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -23,7 +23,7 @@ Solidify your intermediate-level speaking and reading skills in person at our sc
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-monday/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-monday/FW4NG6AUL43RJOFT4OR7VUFQ?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/0qcToXY7' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ For students who have completed intermediate Italian and want to push further in
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-advanced-monday/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-advanced-monday/LFK4ZDK4OWW6K552TEUARTTG?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/XJGbZFpy' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -53,7 +53,7 @@ A bridge class from beginner to intermediate, focused on strengthening conversat
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-tuesday/ZAOWGJEZCVSL75CNRCC4EKTB' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-tuesday/ZAOWGJEZCVSL75CNRCC4EKTB?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/AgTAJS9K' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -68,7 +68,7 @@ Evening section to build grammar and conversation in person.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-thursday/CC4AAHXH5LVKOB6ZICWTLH7O' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-thursday/CC4AAHXH5LVKOB6ZICWTLH7O?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/6kVEfJDr' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -83,7 +83,7 @@ Learn Italian via Zoom from home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-monday-online/QPX5HZQYK3XHAYFMEBBFTYHR' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-monday-online/QPX5HZQYK3XHAYFMEBBFTYHR?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/XjuivUoU' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---
@@ -98,7 +98,7 @@ Continuing intermediate class via Zoom with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-tuesday-online/SATQ6IVPXQOHZIDWF4YQLWTB' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-tuesday-online/SATQ6IVPXQOHZIDWF4YQLWTB?cp=true&sa=false&sbp=false&q=false&category_id=HNRP2GMCHRKHHOJTPN3NQ4QW' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/srHUleCm' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -23,8 +23,8 @@ Solidify your intermediate-level speaking and reading skills in person at our sc
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/CEIS4KXDAWNOY73U4XX2A5OV' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/2tpwhhjb' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/0qcToXY7' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -37,8 +37,8 @@ A bridge class from beginner to intermediate, focused on strengthening conversat
 - **Holidays (No Class):** November 24 (Thanksgiving Week), December 15 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/HRMZK5HMXIV2A5SFKVWKLFZ3' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/TSu8SgSs' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/ZAOWGJEZCVSL75CNRCC4EKTB' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/AgTAJS9K' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -51,8 +51,8 @@ Evening section to build grammar and conversation in person.
 - **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/RJ6A5YDUP4IFGXZHE2OKZFIG' class="btn raise">Pay in Full ($576)</a></div>
-<div class="tc"><a href='https://square.link/u/02P3Maxr' class="btn raise">5 Monthly Payments of $126.72</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/CC4AAHXH5LVKOB6ZICWTLH7O' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/6kVEfJDr' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 
@@ -66,8 +66,8 @@ Learn Italian via Zoom from home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/ADZV3ZI3T2X2SAFESDK2MHN5' class="btn raise">Pay in Full ($544)</a></div>
-<div class="tc"><a href='https://square.link/u/xwtmIDeD' class="btn raise">5 Monthly Payments of $119.68</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/QPX5HZQYK3XHAYFMEBBFTYHR' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/XjuivUoU' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---
 
@@ -81,8 +81,8 @@ Continuing intermediate class via Zoom with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/52PMA5IELAB7DGNSAMSFAMFF' class="btn raise">Pay in Full ($544)</a></div>
-<div class="tc"><a href='https://square.link/u/RpMcCs5q' class="btn raise">5 Monthly Payments of $119.68</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/SATQ6IVPXQOHZIDWF4YQLWTB' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/srHUleCm' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---
 

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -23,7 +23,7 @@ Solidify your intermediate-level speaking and reading skills in person at our sc
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-monday/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/0qcToXY7' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -38,7 +38,7 @@ For students who have completed intermediate Italian and want to push further in
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-advanced-monday/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/XJGbZFpy' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -53,7 +53,7 @@ A bridge class from beginner to intermediate, focused on strengthening conversat
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/ZAOWGJEZCVSL75CNRCC4EKTB' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-tuesday/ZAOWGJEZCVSL75CNRCC4EKTB' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/AgTAJS9K' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -68,7 +68,7 @@ Evening section to build grammar and conversation in person.
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
 - **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/CC4AAHXH5LVKOB6ZICWTLH7O' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-thursday/CC4AAHXH5LVKOB6ZICWTLH7O' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/6kVEfJDr' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
@@ -83,7 +83,7 @@ Learn Italian via Zoom from home with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/QPX5HZQYK3XHAYFMEBBFTYHR' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-beg-int-monday-online/QPX5HZQYK3XHAYFMEBBFTYHR' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/XjuivUoU' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---
@@ -98,7 +98,7 @@ Continuing intermediate class via Zoom with **Tania**.
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
 - **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
-<div class="tc"><a href='https://italianschoolsd.square.site/product/SATQ6IVPXQOHZIDWF4YQLWTB' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://italianschoolsd.square.site/product/fall-2026-italian-class-intermediate-tuesday-online/SATQ6IVPXQOHZIDWF4YQLWTB' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/srHUleCm' class="btn raise">5 Monthly Payments of $119.68</a></div>
 
 ---

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -1,6 +1,7 @@
 ---
 title: "Intermediate Adult Italian Classes: Fall 2026"
 date: 2026-06-28
+weight: 2
 description: Schedule and tuition details for intermediate-level and beginner-intermediate adult Italian classes offered August through December 2026.
 ---
 

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -1,0 +1,94 @@
+---
+title: "Intermediate Adult Italian Classes: Fall 2026"
+date: 2026-06-28
+description: Schedule and tuition details for intermediate-level and beginner-intermediate adult Italian classes offered August through December 2026.
+---
+
+Expand your Italian language skills with our intermediate and beginner-intermediate classes! These sections are designed for students who have studied basic Italian and want to deepen their understanding of vocabulary, conversational skills, and core grammar.
+
+Our Fall session runs for **16 weeks** from **the week of August 17th to December 19th, 2026**.
+
+For other levels, please see our [Adult classes overview]({{< relref "adults.md" >}}), where you will find policies, discounts, and payment plan information.
+
+---
+
+## Monday Intermediate (In person) {#mon-int}
+
+Solidify your intermediate-level speaking and reading skills in person at our school.
+
+- **Teacher:** TBD
+- **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
+- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/CEIS4KXDAWNOY73U4XX2A5OV' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/2tpwhhjb' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Tuesday Beginner-Intermediate (In person) {#tue-beg-int}
+
+A bridge class from beginner to intermediate, focused on strengthening conversational basics.
+
+- **Teacher:** TBD
+- **Schedule:** Tuesdays, 5:30 PM – 7:00 PM, August 18 – December 8, 2026 (16 classes)
+- **Holidays (No Class):** November 24 (Thanksgiving Week), December 15 (Pre-winter break skip)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/HRMZK5HMXIV2A5SFKVWKLFZ3' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/TSu8SgSs' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Thursday Beginner-Intermediate (In person) {#thu-beg-int}
+
+Evening section to build grammar and conversation in person.
+
+- **Teacher:** TBD
+- **Schedule:** Thursdays, 6:30 PM – 8:00 PM, August 20 – December 10, 2026 (16 classes)
+- **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/RJ6A5YDUP4IFGXZHE2OKZFIG' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/02P3Maxr' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Monday Beginner-Intermediate (Online) {#mon-beg-int-online}
+
+Learn Italian via Zoom from home with **Tania**.
+
+- **Teacher:** Tania Adami
+- **Schedule:** Mondays, 6:00 PM – 7:30 PM PST, August 17 – December 14, 2026 (16 classes)
+- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
+- **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/ADZV3ZI3T2X2SAFESDK2MHN5' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/xwtmIDeD' class="btn raise">5 Monthly Payments of $119.68</a></div>
+
+---
+
+## Tuesday Intermediate (Online) {#tue-int-online}
+
+Continuing intermediate class via Zoom with **Tania**.
+
+- **Teacher:** Tania Adami
+- **Schedule:** Tuesdays, 6:00 PM – 7:30 PM PST, August 18 – December 8, 2026 (16 classes)
+- **Holidays (No Class):** November 24 (Thanksgiving Week), December 15 (Pre-winter break skip)
+- **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/52PMA5IELAB7DGNSAMSFAMFF' class="btn raise">Pay in Full ($544)</a></div>
+<div class="tc"><a href='https://square.link/u/RpMcCs5q' class="btn raise">5 Monthly Payments of $119.68</a></div>
+
+---
+
+### Policies & Discounts
+
+- **Family Discount:** 10% off for all additional family members enrolling together (applied automatically at checkout).
+- **Payment Plan Commitment:** Choosing a payment plan is a commitment to the entire duration of the class. It is not a monthly subscription that can be canceled mid-session.
+- **Refunds:** Full refund if canceled 15 days before the first class; 50% refund before the second class; no refunds after the second class.
+
+Questions? [Contact us]({{< relref "contact.md" >}}) and we'll be happy to help!

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -21,7 +21,7 @@ Solidify your intermediate-level speaking and reading skills in person at our sc
 - **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
 - **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
-- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
+- **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/0qcToXY7' class="btn raise">5 Monthly Payments of $126.72</a></div>
@@ -36,6 +36,7 @@ A bridge class from beginner to intermediate, focused on strengthening conversat
 - **Schedule:** Tuesdays, 5:30 PM – 7:00 PM, August 18 – December 8, 2026 (16 classes)
 - **Holidays (No Class):** November 24 (Thanksgiving Week), December 15 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/ZAOWGJEZCVSL75CNRCC4EKTB' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/AgTAJS9K' class="btn raise">5 Monthly Payments of $126.72</a></div>
@@ -50,6 +51,7 @@ Evening section to build grammar and conversation in person.
 - **Schedule:** Thursdays, 6:30 PM – 8:00 PM, August 20 – December 10, 2026 (16 classes)
 - **Holidays (No Class):** November 26 (Thanksgiving Day), December 17 (Pre-winter break skip)
 - **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1a* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1a/1?cp=true&sa=false&sbp=false&q=true)).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/CC4AAHXH5LVKOB6ZICWTLH7O' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/6kVEfJDr' class="btn raise">5 Monthly Payments of $126.72</a></div>
@@ -64,7 +66,7 @@ Learn Italian via Zoom from home with **Tania**.
 - **Schedule:** Mondays, 6:00 PM – 7:30 PM PST, August 17 – December 14, 2026 (16 classes)
 - **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
-- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/QPX5HZQYK3XHAYFMEBBFTYHR' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/XjuivUoU' class="btn raise">5 Monthly Payments of $119.68</a></div>
@@ -79,7 +81,7 @@ Continuing intermediate class via Zoom with **Tania**.
 - **Schedule:** Tuesdays, 6:00 PM – 7:30 PM PST, August 18 – December 8, 2026 (16 classes)
 - **Holidays (No Class):** November 24 (Thanksgiving Week), December 15 (Pre-winter break skip)
 - **Tuition:** $544 for the full session (or 5 monthly payments of $119.68)
-- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)* ([available on Amazon](https://a.co/d/0hAj20Up)).
+- **Textbook:** This class uses *New Italian Espresso (Beginner/Pre-Intermediate Updated Edition)*: [Textbook](https://a.co/d/0hAj20Up) and [Workbook](https://a.co/d/0fGK4Sfo) (available on Amazon).
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/SATQ6IVPXQOHZIDWF4YQLWTB' class="btn raise">Pay in Full ($544)</a></div>
 <div class="tc"><a href='https://square.link/u/srHUleCm' class="btn raise">5 Monthly Payments of $119.68</a></div>

--- a/site/content/news/adult-intermediate-classes-fall-2026.md
+++ b/site/content/news/adult-intermediate-classes-fall-2026.md
@@ -1,8 +1,8 @@
 ---
-title: "Intermediate Adult Italian Classes: Fall 2026"
+title: "Intermediate & Intermediate-Advanced Adult Italian Classes: Fall 2026"
 date: 2026-06-28
 weight: 2
-description: Schedule and tuition details for intermediate-level and beginner-intermediate adult Italian classes offered August through December 2026.
+description: Schedule and tuition details for intermediate-level, beginner-intermediate, and intermediate-advanced adult Italian classes offered August through December 2026.
 ---
 
 Expand your Italian language skills with our intermediate and beginner-intermediate classes! These sections are designed for students who have studied basic Italian and want to deepen their understanding of vocabulary, conversational skills, and core grammar.
@@ -25,6 +25,21 @@ Solidify your intermediate-level speaking and reading skills in person at our sc
 
 <div class="tc"><a href='https://italianschoolsd.square.site/product/FW4NG6AUL43RJOFT4OR7VUFQ' class="btn raise">Pay in Full ($576)</a></div>
 <div class="tc"><a href='https://square.link/u/0qcToXY7' class="btn raise">5 Monthly Payments of $126.72</a></div>
+
+---
+
+## Monday Intermediate-Advanced (In person) {#mon-int-adv}
+
+For students who have completed intermediate Italian and want to push further into complex grammar, nuanced vocabulary, and fluent expression.
+
+- **Teacher:** TBD
+- **Schedule:** Mondays, 6:00 PM – 7:30 PM, August 17 – December 14, 2026 (16 classes)
+- **Holidays (No Class):** September 7 (Labor Day), November 23 (Thanksgiving Week)
+- **Tuition:** $576 for the full session (or 5 monthly payments of $126.72)
+- **Textbook:** This class uses *The New Italian Project 1b* ([purchase it here](https://italianschoolsd.square.site/product/new-italian-project-1b/7QEYHDOUF5FWPGRPUBIKCWIC?cp=true&sa=false&sbp=false&q=true)).
+
+<div class="tc"><a href='https://italianschoolsd.square.site/product/LFK4ZDK4OWW6K552TEUARTTG' class="btn raise">Pay in Full ($576)</a></div>
+<div class="tc"><a href='https://square.link/u/XJGbZFpy' class="btn raise">5 Monthly Payments of $126.72</a></div>
 
 ---
 


### PR DESCRIPTION
This pull request adds the schedule and registration details for the Fall 2026 Adult Italian classes.

Key changes:
- Created and linked Square products for all 11 courses (weekday in-person, Saturday in-person, and online virtual).
- Created and linked 5-payment plan subscriptions for all courses (with a 10% administrative fee for financing).
- Updated `/site/content/adults.md` with the new Fall 2026 weekly schedule, enrollment links, and payment plan policy.
- Created separate news posts under `/site/content/news/` for Beginner, Intermediate, and Advanced/Conversation levels to keep registration pathways clear.
