### PR TITLE
Add Italian Clearly book landing page

### DIFF
--- a/site/content/italian-clearly.md
+++ b/site/content/italian-clearly.md
@@ -1,7 +1,7 @@
 ---
 title: "Italian, Clearly"
 subtitle: "A Visual Grammar Cheat Sheet for English Speakers"
-description: "A compact A1-A2 Italian grammar reference with visual patterns, original bilingual examples, common traps, and quick checks."
+description: "A compact A1-A2 Italian grammar reference built around concise rules, visual tables, and original bilingual examples."
 image: /img/book_collage_may2026.jpg
 ---
 
@@ -9,7 +9,7 @@ image: /img/book_collage_may2026.jpg
   <img src="/img/italian-clearly-cover.svg" alt="Cover of Italian, Clearly: A Visual Grammar Cheat Sheet for English Speakers" style="width: min(100%, 420px);">
 </div>
 
-**Italian, Clearly** is a compact A1-A2 grammar reference created for English-speaking learners. It explains essential Italian patterns in plain English, then reinforces each one with new bilingual examples and two quick checks.
+**Italian, Clearly** is a compact A1-A2 grammar reference created for English-speaking learners. It presents essential Italian through concise rules, visual tables, and original bilingual examples.
 
 Written and published by **Italian school of San Diego LLC**.
 
@@ -27,18 +27,15 @@ The book is in final editorial and print-proof review. Purchase links will appea
 
 ## What makes it clear {#what-makes-it-clear}
 
-Every grammar topic follows the same six-part map:
+Every grammar topic follows the same three-part format:
 
-1. **Rule:** the shortest accurate explanation
-2. **Pattern:** a table that makes the moving parts visible
-3. **English connection:** where English habits can interfere
-4. **Examples:** three original Italian sentences with natural English meanings
-5. **Common trap:** a frequent mistake and how to avoid it
-6. **Quick check:** two short questions, with answers at the back
+1. **Rule:** only the explanation needed to use the pattern
+2. **Pattern:** a table showing the forms or choices
+3. **Examples:** three original Italian sentences with natural English meanings
 
 ## What is inside {#what-is-inside}
 
-The 84-page first-edition draft covers:
+The 72-page first-edition draft covers:
 
 * Italian sounds, spelling, and syllables
 * nouns, articles, plurals, adjectives, and possessives
@@ -46,7 +43,7 @@ The 84-page first-edition draft covers:
 * reflexive verbs and *piacere*
 * questions, negation, pronouns, adverbs, and prepositions
 * *passato prossimo*, *imperfetto*, and the future tense
-* quick-reference tables, an answer key, and a compact index
+* quick-reference tables and a compact index
 
 ## Original examples {#original-examples}
 

--- a/site/content/italian-clearly.md
+++ b/site/content/italian-clearly.md
@@ -1,0 +1,70 @@
+---
+title: "Italian, Clearly"
+subtitle: "A Visual Grammar Cheat Sheet for English Speakers"
+description: "A compact A1-A2 Italian grammar reference with visual patterns, original bilingual examples, common traps, and quick checks."
+image: /img/book_collage_may2026.jpg
+---
+
+<div class="tc">
+  <img src="/img/italian-clearly-cover.svg" alt="Cover of Italian, Clearly: A Visual Grammar Cheat Sheet for English Speakers" style="width: min(100%, 420px);">
+</div>
+
+**Italian, Clearly** is a compact A1-A2 grammar reference created for English-speaking learners. It explains essential Italian patterns in plain English, then reinforces each one with new bilingual examples and two quick checks.
+
+Written and published by **Italian school of San Diego LLC**.
+
+## Formats and launch prices {#formats-and-prices}
+
+* **Paperback, $12.99:** 6 x 9 inch black-and-white reference book
+* **Kindle ebook, $5.99:** reflowable Kindle edition
+* **Direct digital edition, $7.99:** PDF and EPUB files
+
+The book is in final editorial and print-proof review. Purchase links will appear here after the physical proof and store listings are approved.
+
+<div class="tc">
+<a href='{{< relref "contact/_index.md" >}}' class="btn raise">Ask about publication updates</a>
+</div>
+
+## What makes it clear {#what-makes-it-clear}
+
+Every grammar topic follows the same six-part map:
+
+1. **Rule:** the shortest accurate explanation
+2. **Pattern:** a table that makes the moving parts visible
+3. **English connection:** where English habits can interfere
+4. **Examples:** three original Italian sentences with natural English meanings
+5. **Common trap:** a frequent mistake and how to avoid it
+6. **Quick check:** two short questions, with answers at the back
+
+## What is inside {#what-is-inside}
+
+The 84-page first-edition draft covers:
+
+* Italian sounds, spelling, and syllables
+* nouns, articles, plurals, adjectives, and possessives
+* regular and high-frequency irregular present-tense verbs
+* reflexive verbs and *piacere*
+* questions, negation, pronouns, adverbs, and prepositions
+* *passato prossimo*, *imperfetto*, and the future tense
+* quick-reference tables, an answer key, and a compact index
+
+## Original examples {#original-examples}
+
+The book contains 147 newly written bilingual examples. They were checked against the school's 20 reference PDFs so that none of the example sentences reuse the source material verbatim or as a close match.
+
+## Who it is for {#who-it-is-for}
+
+This guide is designed for:
+
+* adults beginning Italian or reviewing levels A1-A2
+* English speakers who want a concise explanation of Italian structure
+* travelers and independent learners who need a quick reference
+* students who want a companion to a class or textbook
+
+It is a reference guide, not a replacement for a complete language course.
+
+## Buying directly from the school {#buy-directly}
+
+After launch, students will be able to buy the paperback directly from the school for local pickup. The PDF and EPUB bundle will also be available from this website. Amazon will carry the paperback and Kindle editions.
+
+No Kindle exclusivity is planned, so the digital edition can remain available directly from the school.

--- a/site/static/img/italian-clearly-cover.svg
+++ b/site/static/img/italian-clearly-cover.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="2560" viewBox="0 0 1600 2560" role="img" aria-labelledby="title desc">
+  <title id="title">Italian, Clearly book cover</title>
+  <desc id="desc">A clean green, cream, and red cover with a speech bubble and grammar table motif.</desc>
+  <rect width="1600" height="2560" fill="#f7f1df"/>
+  <rect width="1600" height="92" y="0" fill="#287b6d"/>
+  <rect width="1600" height="92" y="2468" fill="#a33b36"/>
+  <circle cx="800" cy="640" r="390" fill="#ffffff" stroke="#287b6d" stroke-width="28"/>
+  <path d="M560 885 L470 1080 L720 940" fill="#ffffff" stroke="#287b6d" stroke-width="28" stroke-linejoin="round"/>
+  <g font-family="DejaVu Sans, sans-serif" text-anchor="middle" fill="#1f2927">
+    <text x="800" y="570" font-size="125" font-weight="700">ITALIAN,</text>
+    <text x="800" y="715" font-size="125" font-weight="700" fill="#287b6d">CLEARLY</text>
+    <text x="800" y="1260" font-size="55" font-weight="600">A VISUAL GRAMMAR CHEAT SHEET</text>
+    <text x="800" y="1335" font-size="55" font-weight="600">FOR ENGLISH SPEAKERS</text>
+  </g>
+  <g transform="translate(260 1530)" font-family="DejaVu Sans, sans-serif" font-size="43">
+    <rect width="1080" height="420" rx="24" fill="#ffffff" stroke="#1f2927" stroke-width="7"/>
+    <path d="M0 105 H1080 M0 210 H1080 M0 315 H1080 M360 0 V420 M720 0 V420" stroke="#777" stroke-width="4"/>
+    <g text-anchor="middle" dominant-baseline="middle">
+      <text x="180" y="55" font-weight="700">PATTERN</text>
+      <text x="540" y="55" font-weight="700">EXAMPLE</text>
+      <text x="900" y="55" font-weight="700">MEANING</text>
+      <text x="180" y="158">-o → -i</text>
+      <text x="540" y="158" font-style="italic">libro → libri</text>
+      <text x="900" y="158">book → books</text>
+      <text x="180" y="263">-a → -e</text>
+      <text x="540" y="263" font-style="italic">casa → case</text>
+      <text x="900" y="263">house → houses</text>
+      <text x="180" y="368">-e → -i</text>
+      <text x="540" y="368" font-style="italic">notte → notti</text>
+      <text x="900" y="368">night → nights</text>
+    </g>
+  </g>
+  <text x="800" y="2240" font-family="DejaVu Sans, sans-serif" font-size="48" font-weight="700" text-anchor="middle" fill="#1f2927">Italian school of San Diego LLC</text>
+</svg>


### PR DESCRIPTION
## What changed

- adds the Italian, Clearly landing page and cover asset
- presents the 72-page table-first format and planned launch prices
- describes the concise Rule, Pattern, and Examples structure
- keeps purchasing disabled until editorial and print-proof approval

## Why

The book needs a reviewable customer-facing page before its Amazon and Square listings are published.

## Validation

- `npm run build:hugo`
- verified the rendered 72-page description and three-part structure
- verified the cover asset, section anchors, and contact link locally
- previously checked desktop and mobile layouts with Playwright
