### PR TITLE
ZON-206: reorganize adult classes page

### DIFF
--- a/site/assets/css/imports/_adult-classes.scss
+++ b/site/assets/css/imports/_adult-classes.scss
@@ -264,10 +264,10 @@
 }
 
 .cms .adult-option-card .btn {
-  align-self: flex-start;
+  align-self: stretch;
   font-size: 0.88rem;
   margin: auto 0 0;
-  width: 100%;
+  width: auto;
 }
 
 .cms .adult-text-link {
@@ -315,11 +315,6 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.25rem;
-}
-
-.adult-feature-callout-language {
-  background: linear-gradient(135deg, #f3edfb, #fbf9fd);
-  border-color: #ddd0ee;
 }
 
 .cms .adult-feature-callout h3 {

--- a/site/assets/css/imports/_adult-classes.scss
+++ b/site/assets/css/imports/_adult-classes.scss
@@ -1,0 +1,455 @@
+.adult-page {
+  color: var(--black);
+}
+
+.adult-page > h2 {
+  margin-top: 3rem;
+}
+
+.adult-hero-panel {
+  background:
+    radial-gradient(circle at 100% 0, rgba(255, 255, 255, 0.17), transparent 38%),
+    linear-gradient(135deg, #004f88, var(--primary));
+  border-radius: 0.75rem;
+  box-shadow: 0 16px 34px rgba(0, 79, 136, 0.18);
+  color: var(--white);
+  margin-bottom: 1rem;
+  overflow: hidden;
+  padding: 1.5rem;
+}
+
+.cms .adult-hero-panel h2 {
+  color: var(--white);
+  font-size: clamp(1.65rem, 5vw, 2.25rem);
+  margin: 0 0 0.65rem;
+  max-width: 18ch;
+}
+
+.adult-hero-panel > p:not(.adult-eyebrow) {
+  font-size: 1.05rem;
+  margin: 0;
+  max-width: 38rem;
+}
+
+.adult-eyebrow,
+.adult-card-kicker {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+}
+
+.adult-eyebrow {
+  color: #c9edff;
+}
+
+.adult-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+
+.cms .adult-hero-actions .btn {
+  background: var(--white);
+  color: var(--primary);
+  margin: 0;
+}
+
+.cms .adult-hero-actions .btn:last-child {
+  background: transparent;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.72);
+  color: var(--white);
+}
+
+.cms .adult-hero-actions .btn:hover,
+.cms .adult-hero-actions .btn:focus {
+  background: #dff3ff;
+  box-shadow: none;
+  color: #003c68;
+}
+
+.adult-jump-links {
+  display: flex;
+  gap: 0.45rem;
+  margin: 1rem 0;
+  overflow-x: auto;
+  padding: 0.15rem 0 0.45rem;
+  scrollbar-width: thin;
+}
+
+.cms .adult-jump-links a {
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-radius: 999px;
+  color: var(--primary);
+  flex: 0 0 auto;
+  font-size: 0.83rem;
+  font-weight: 800;
+  padding: 0.55rem 0.8rem;
+  text-decoration: none;
+}
+
+.cms .adult-jump-links a:hover,
+.cms .adult-jump-links a:focus {
+  background: #eaf7ff;
+  border-color: rgba(0, 100, 170, 0.35);
+}
+
+.adult-location-note {
+  background: #eef8f3;
+  border-left: 4px solid #21865d;
+  border-radius: 0 0.4rem 0.4rem 0;
+  color: #245343;
+  padding: 0.85rem 1rem;
+}
+
+.adult-session-facts {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
+  margin: 1.25rem 0 0;
+}
+
+.adult-session-facts > div {
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-radius: 0.55rem;
+  box-shadow: 0 6px 16px rgba(43, 37, 35, 0.05);
+  padding: 1rem;
+}
+
+.adult-session-facts dt {
+  color: var(--grey-3);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.adult-session-facts dd {
+  color: var(--primary);
+  font-size: 1.22rem;
+  font-weight: 800;
+  margin: 0.15rem 0 0;
+}
+
+.adult-session-facts span {
+  color: var(--grey-3);
+  display: block;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+.adult-schedule-grid,
+.adult-option-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin-top: 1.25rem;
+}
+
+.adult-day-card,
+.adult-option-card {
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-radius: 0.65rem;
+  box-shadow: 0 8px 22px rgba(43, 37, 35, 0.07);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.cms .adult-day-card h3 {
+  background: linear-gradient(90deg, #005f9f, var(--primary));
+  color: var(--white);
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+}
+
+.adult-class-row {
+  align-items: start;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 0.9rem 1rem;
+}
+
+.adult-class-row + .adult-class-row {
+  border-top: 1px solid var(--grey-2);
+}
+
+.adult-class-row > div,
+.adult-class-row > p {
+  min-width: 0;
+}
+
+.adult-class-row strong {
+  display: block;
+  line-height: 1.25;
+}
+
+.adult-class-row p {
+  margin: 0;
+  text-align: right;
+}
+
+.adult-class-row p span,
+.adult-class-row p small {
+  display: block;
+}
+
+.adult-class-row p span {
+  color: var(--black);
+  font-size: 0.9rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.adult-class-row p small {
+  color: var(--grey-3);
+  font-size: 0.76rem;
+  line-height: 1.3;
+  margin-top: 0.15rem;
+}
+
+.adult-format {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  margin-top: 0.4rem;
+  padding: 0.18rem 0.48rem;
+  text-transform: uppercase;
+}
+
+.adult-format-in-person {
+  background: #e4f6ec;
+  color: #12613f;
+}
+
+.adult-format-online {
+  background: #e5f3fd;
+  color: #005c99;
+}
+
+.adult-format-encinitas {
+  background: #f4eafd;
+  color: #69408c;
+}
+
+.adult-option-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.15rem;
+}
+
+.adult-card-kicker {
+  color: #21865d;
+}
+
+.cms .adult-option-card h3 {
+  color: var(--primary);
+  font-size: 1.25rem;
+  margin: 0 0 0.55rem;
+}
+
+.adult-option-card > p:not(.adult-card-kicker) {
+  color: var(--grey-4);
+  margin: 0 0 1rem;
+}
+
+.cms .adult-option-card .btn {
+  align-self: flex-start;
+  font-size: 0.88rem;
+  margin: auto 0 0;
+  width: 100%;
+}
+
+.cms .adult-text-link {
+  align-self: flex-start;
+  font-weight: 800;
+  margin-top: auto;
+  text-decoration: none;
+}
+
+.adult-help-strip {
+  align-items: center;
+  background: #eaf7ff;
+  border: 1px solid #c4e7fb;
+  border-radius: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.adult-help-strip strong,
+.adult-help-strip span {
+  display: block;
+}
+
+.adult-help-strip span {
+  color: var(--grey-4);
+  font-size: 0.9rem;
+  margin-top: 0.15rem;
+}
+
+.cms .adult-help-strip .btn {
+  flex: 0 0 auto;
+  margin: 0;
+  width: 100%;
+}
+
+.adult-feature-callout {
+  align-items: center;
+  background: linear-gradient(135deg, #eef8f3, #f8fcfa);
+  border: 1px solid #cfe6da;
+  border-radius: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.adult-feature-callout-language {
+  background: linear-gradient(135deg, #f3edfb, #fbf9fd);
+  border-color: #ddd0ee;
+}
+
+.cms .adult-feature-callout h3 {
+  color: var(--primary);
+  font-size: 1.25rem;
+  margin: 0 0 0.55rem;
+}
+
+.adult-feature-callout p:last-child {
+  margin-bottom: 0;
+}
+
+.cms .adult-feature-callout .btn {
+  flex: 0 0 auto;
+  margin: 0;
+  width: 100%;
+}
+
+.adult-policy-list {
+  border-bottom: 1px solid var(--grey-2);
+  margin-top: 1.25rem;
+}
+
+.adult-policy-list details {
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-bottom: 0;
+}
+
+.adult-policy-list details:first-child {
+  border-radius: 0.6rem 0.6rem 0 0;
+}
+
+.adult-policy-list details:last-child {
+  border-radius: 0 0 0.6rem 0.6rem;
+}
+
+.adult-policy-list summary {
+  color: var(--primary);
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0.9rem 1rem;
+}
+
+.adult-policy-list summary:hover,
+.adult-policy-list summary:focus {
+  background: #f2f9fd;
+}
+
+.adult-policy-list details[open] summary {
+  border-bottom: 1px solid var(--grey-2);
+}
+
+.adult-policy-list details > :not(summary) {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.adult-policy-list details > :last-child {
+  margin-bottom: 1rem;
+}
+
+.adult-archive-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.cms .adult-archive-links a {
+  background: var(--white);
+  border: 1px solid var(--grey-2);
+  border-radius: 0.4rem;
+  font-weight: 800;
+  padding: 0.6rem 0.8rem;
+  text-decoration: none;
+}
+
+@media (min-width: 36rem) {
+  .adult-session-facts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .adult-help-strip {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .adult-feature-callout {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .cms .adult-help-strip .btn,
+  .cms .adult-feature-callout .btn {
+    width: auto;
+  }
+}
+
+@media (min-width: 48rem) {
+  .adult-hero-panel {
+    padding: 2rem;
+  }
+
+  .adult-schedule-grid,
+  .adult-option-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .adult-level-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .adult-day-card-compact {
+    align-self: start;
+  }
+}
+
+@media (max-width: 30rem) {
+  .adult-class-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .adult-class-row p {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .adult-page * {
+    scroll-behavior: auto;
+  }
+}

--- a/site/assets/css/main.scss
+++ b/site/assets/css/main.scss
@@ -73,6 +73,7 @@
 @import './imports/_buttons';
 @import './imports/_svg';
 @import './imports/_cms';
+@import './imports/_adult-classes';
 @import './imports/_docsearch';
 
 /* Variables */

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -23,7 +23,6 @@ subtitle: Italian classes in person across San Diego County and online via Zoom
   <a href='{{< relref "adults.md" >}}#course-levels'>Choose your level</a>
   <a href='{{< relref "adults.md" >}}#encinitas'>Encinitas classes</a>
   <a href='{{< relref "adults.md" >}}#private-custom'>Flexible options</a>
-  <a href='{{< relref "adults.md" >}}#world-languages'>Other languages</a>
   <a href='{{< relref "adults.md" >}}#policies'>Policies and discounts</a>
 </nav>
 
@@ -205,18 +204,6 @@ Scan by day, then use the level guides below for full dates, tuition, holidays, 
     <a href="/contact" class="adult-text-link">Discuss a custom class <span aria-hidden="true">→</span></a>
   </article>
 </div>
-
-## World languages for adults {#world-languages}
-
-<section class="adult-feature-callout adult-feature-callout-language" aria-labelledby="world-language-details">
-  <div>
-    <p class="adult-card-kicker">More ways to learn</p>
-    <h3 id="world-language-details">Beginner Spanish, German, and English</h3>
-    <p>Starting September 15, 2026, small in-person classes meet on Tuesdays from <strong>6:00–7:30 PM</strong>. The English class is designed for Spanish-speaking adults.</p>
-    <p>These programs bring our practical, community-centered approach to languages beyond Italian.</p>
-  </div>
-  <a href="/news/2026/08/world-language-classes-san-diego-fall-2026/" class="btn btn-cta">World language schedules</a>
-</section>
 
 ## Policies, discounts, and payment plans {#policies}
 

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -3,127 +3,253 @@ title: Adult classes
 image: /img/lastsupper.jpg
 aliases:
     - /enroll-adults
-subtitle: Italian classes In-person in San Diego & via Zoom
+subtitle: Italian classes in person across San Diego County and online via Zoom
 ---
 
-Welcome! Below you’ll find all our current and upcoming Italian classes for adults. If you don’t see a class that fits your needs, please fill out our interest form and we’ll contact you within a couple of days to discuss options:
+<div class="adult-page">
 
-<div class="tc">
-<a href="https://forms.gle/LHR7Htpeb3mQzV838" class="btn raise">Adult Italian lesson interest form</a>
+<section class="adult-hero-panel" aria-labelledby="adult-welcome">
+  <p class="adult-eyebrow">Learn Italian your way</p>
+  <h2 id="adult-welcome">Find the right class for your level and schedule</h2>
+  <p>Choose from weekly group classes, flexible private lessons, and custom programs. All Italian classes are led by native Italian-speaking instructors.</p>
+  <div class="adult-hero-actions">
+    <a href="#weekly-schedule" class="btn btn-cta">See the Fall schedule</a>
+    <a href="https://forms.gle/LHR7Htpeb3mQzV838" class="btn btn-cta">Tell us what you need</a>
+  </div>
+</section>
+
+<nav class="adult-jump-links" aria-label="Adult classes page sections">
+  <a href="#fall-2026">Fall group classes</a>
+  <a href="#course-levels">Choose your level</a>
+  <a href="#encinitas">Encinitas classes</a>
+  <a href="#private-custom">Flexible options</a>
+  <a href="#world-languages">Other languages</a>
+  <a href="#policies">Policies and discounts</a>
+</nav>
+
+<p class="adult-location-note"><strong>In-person classes:</strong> Most classes meet at our school at <a href='{{< relref "location.md" >}}'>4550 Kearny Villa Rd, Suite 202</a> in Kearny Mesa. Friday classes meet at our <a href='{{< relref "italian-classes-encinitas.md" >}}'>Encinitas location</a>.</p>
+
+## Fall 2026 group classes {#fall-2026}
+
+The Fall session runs from **August 17 to December 19, 2026**, with classes in Kearny Mesa, new Friday classes in Encinitas, and online classes via Zoom.
+
+<dl class="adult-session-facts">
+  <div>
+    <dt>Session</dt>
+    <dd>13–16 weeks</dd>
+    <span>Varies by section</span>
+  </div>
+  <div>
+    <dt>Class length</dt>
+    <dd>90 minutes</dd>
+    <span>One class each week</span>
+  </div>
+  <div>
+    <dt>Formats</dt>
+    <dd>In person + online</dd>
+    <span>Native Italian instructors</span>
+  </div>
+</dl>
+
+## Weekly class schedule {#weekly-schedule}
+
+Scan by day, then use the level guides below for full dates, tuition, holidays, and enrollment.
+
+<div class="adult-schedule-grid">
+  <article class="adult-day-card">
+    <h3 id="monday-classes">Monday</h3>
+    <div class="adult-class-row">
+      <div><strong>Intermediate</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:00–7:30 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Intermediate–Advanced</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:00–7:30 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Advanced</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:00–7:30 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Beginner–Intermediate</strong><span class="adult-format adult-format-online">Online</span></div>
+      <p><span>6:00–7:30 PM</span><small>Tania Adami</small></p>
+    </div>
+  </article>
+
+  <article class="adult-day-card">
+    <h3 id="tuesday-classes">Tuesday</h3>
+    <div class="adult-class-row">
+      <div><strong>Beginner–Intermediate</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>5:30–7:00 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Intermediate</strong><span class="adult-format adult-format-online">Online</span></div>
+      <p><span>6:00–7:30 PM</span><small>Tania Adami</small></p>
+    </div>
+  </article>
+
+  <article class="adult-day-card">
+    <h3 id="thursday-classes">Thursday</h3>
+    <div class="adult-class-row">
+      <div><strong>Beginner</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:30–8:00 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Beginner–Intermediate</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:30–8:00 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Conversation</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>6:30–8:00 PM</span><small>Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Beginner</strong><span class="adult-format adult-format-online">Online</span></div>
+      <p><span>6:00–7:30 PM</span><small>Tania Adami</small></p>
+    </div>
+  </article>
+
+  <article class="adult-day-card">
+    <h3 id="friday-classes">Friday · Encinitas</h3>
+    <div class="adult-class-row">
+      <div><strong>Beginner</strong><span class="adult-format adult-format-encinitas">Encinitas</span></div>
+      <p><span>6:00–7:30 PM</span><small>13 classes · Teacher to be announced</small></p>
+    </div>
+    <div class="adult-class-row">
+      <div><strong>Intermediate</strong><span class="adult-format adult-format-encinitas">Encinitas</span></div>
+      <p><span>6:00–7:30 PM</span><small>13 classes · Teacher to be announced</small></p>
+    </div>
+  </article>
+
+  <article class="adult-day-card adult-day-card-compact">
+    <h3 id="saturday-classes">Saturday</h3>
+    <div class="adult-class-row">
+      <div><strong>Beginner</strong><span class="adult-format adult-format-in-person">Kearny Mesa</span></div>
+      <p><span>10:00–11:30 AM</span><small>15 classes · Teacher to be announced</small></p>
+    </div>
+  </article>
 </div>
 
-Note: In-person adult classes meet at our school at [4550 Kearny Villa Rd Suite 202]( {{< ref "location.md" >}} ), except the Friday classes in [Encinitas]( {{< ref "italian-classes-encinitas.md" >}} ), our North County location.
+## Choose your level {#course-levels}
 
----
+<div class="adult-option-grid adult-level-grid">
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Start here</p>
+    <h3 id="beginner">Beginner</h3>
+    <p>Build a foundation in practical conversation, vocabulary, grammar, and Italian culture. Choose Kearny Mesa, Encinitas, or online. No prior experience is required.</p>
+    <a href='{{< relref "news/adult-beginner-classes-fall-2026.md" >}}' class="btn btn-cta">Beginner schedule and tuition</a>
+  </article>
 
-## Fall 2026 Group Classes {#fall-2026}
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Keep progressing</p>
+    <h3 id="intermediate">Intermediate</h3>
+    <p>Expand your grammar, vocabulary, and conversational agility, with tracks from Beginner–Intermediate through Intermediate–Advanced in Kearny Mesa, Encinitas, or online.</p>
+    <a href='{{< relref "news/adult-intermediate-classes-fall-2026.md" >}}' class="btn btn-cta">Intermediate schedule and tuition</a>
+  </article>
 
-Our Fall session runs for **16 weeks** (15 weeks for Saturday classes) from **August 17th to December 19th, 2026**. We offer in-person classes in Kearny Mesa, new in-person classes in Encinitas (North County) on Friday evenings, and online virtual classes via Zoom. All of our instructors are native Italian speakers (mother tongue).
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Build fluency</p>
+    <h3 id="advanced">Advanced and conversation</h3>
+    <p>Refine your fluency and advanced grammar while discussing Italian literature, news, and culture in a collaborative setting.</p>
+    <a href='{{< relref "news/adult-advanced-classes-fall-2026.md" >}}' class="btn btn-cta">Advanced schedule and tuition</a>
+  </article>
+</div>
 
-## Detailed Weekly Schedule (All classes 1.5 hours)
+<aside class="adult-help-strip">
+  <div>
+    <strong>Not sure which level fits?</strong>
+    <span>Share your experience and availability, and we’ll help you choose.</span>
+  </div>
+  <a href="https://forms.gle/LHR7Htpeb3mQzV838" class="btn btn-cta">Complete the interest form</a>
+</aside>
 
-| DAY | LEVEL | TEACHER | Time |
-| :--- | :--- | :--- | :--- |
-| **MONDAY** | **Intermediate** | **TBD** | 6:00 PM - 7:30 PM |
-| **MONDAY** | **Intermediate-Advanced** | **TBD** | 6:00 PM - 7:30 PM |
-| **MONDAY** | **Advanced** | **TBD** | 6:00 PM - 7:30 PM |
-| **MONDAY (Online)** | **Beg-Int** | **Tania Adami** | 6:00 PM - 7:30 PM |
-| **TUESDAY** | **Beg-Int** | **TBD** | 5:30 PM - 7:00 PM |
-| **TUESDAY (Online)** | **Intermediate** | **Tania Adami** | 6:00 PM - 7:30 PM |
-| **THURSDAY** | **Beginner** | **TBD** | 6:30 PM - 8:00 PM |
-| **THURSDAY** | **Beg-Int** | **TBD** | 6:30 PM - 8:00 PM |
-| **THURSDAY** | **Conversation** | **TBD** | 6:30 PM - 8:00 PM |
-| **THURSDAY (Online)** | **Beginner** | **Tania Adami** | 6:00 PM - 7:30 PM |
-| **FRIDAY (Encinitas)** | **Beginner** | **TBD** | 6:00 PM - 7:30 PM (13 classes) |
-| **FRIDAY (Encinitas)** | **Intermediate** | **TBD** | 6:00 PM - 7:30 PM (13 classes) |
-| **SATURDAY** | **Beginner** | **TBD** | 10:00 AM - 11:30 AM (15 classes) |
+## North County classes in Encinitas {#encinitas}
 
-Choose your level below to view schedule details, holidays, and enroll online.
+<section class="adult-feature-callout" aria-labelledby="encinitas-details">
+  <div>
+    <p class="adult-card-kicker">New for Fall 2026</p>
+    <h3 id="encinitas-details">Beginner and intermediate Italian on Fridays</h3>
+    <p>Meet at San Dieguito United Methodist Church, <a href="https://maps.google.com/?q=170+Calle+Magdalena,+Encinitas,+CA+92024">170 Calle Magdalena</a>, from <strong>6:00–7:30 PM</strong>, September 18 to December 18 (13 classes).</p>
+    <p><strong>Tuition:</strong> $468 in full or four monthly payments of $128.70.</p>
+  </div>
+  <a href='{{< relref "news/adult-italian-classes-encinitas-north-county-fall-2026.md" >}}' class="btn btn-cta">Encinitas schedule and tuition</a>
+</section>
 
-### Beginner Classes {#beginner}
+## Private and custom classes {#private-custom}
 
-Start your Italian journey with our friendly, hands-on beginner classes! In this session, you'll build a solid foundation in Italian conversation, vocabulary, grammar, and culture—perfect for travel, family connection, or personal enrichment. No prior experience is required. We offer in-person sections (Thursday evening or Saturday morning in Kearny Mesa, Friday evening in Encinitas) and an online section (Thursday evening).
+<div class="adult-option-grid">
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Personalized</p>
+    <h3 id="private">Private lessons</h3>
+    <p>One-on-one lessons in person or via Zoom, with flexible scheduling, a custom curriculum, and a 24-hour cancellation policy. All levels are welcome.</p>
+    <a href='{{< relref "italian-private-classes.md" >}}' class="adult-text-link">Explore private lessons <span aria-hidden="true">→</span></a>
+  </article>
 
-<div class="tc"><a href='{{< relref "news/adult-beginner-classes-fall-2026.md" >}}' class="btn raise">View Fall Beginner schedule & tuition</a></div>
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Most flexible · Online only</p>
+    <h3 id="on-demand">Italian On Demand</h3>
+    <p>Book an online private lesson with as little as 12 hours’ notice and pay per session, with no long-term commitment.</p>
+    <a href='{{< relref "italian-on-demand.md" >}}' class="adult-text-link">Explore online lessons <span aria-hidden="true">→</span></a>
+  </article>
 
-### Intermediate & Intermediate-Advanced {#intermediate}
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">For organizations</p>
+    <h3 id="business">Italian for businesses</h3>
+    <p>Custom language and cultural training for your team, delivered in San Diego or online and adapted to your industry.</p>
+    <a href='{{< relref "italian-private-classes-business-san-diego.md" >}}' class="adult-text-link">Explore corporate training <span aria-hidden="true">→</span></a>
+  </article>
 
-For students with at least some prior study who want to expand their grammar, vocabulary, and conversational agility. We offer multiple tracks — including a dedicated Intermediate-Advanced section — in person on Monday, Tuesday, or Thursday in Kearny Mesa, on Friday in Encinitas, and online on Monday or Tuesday.
-
-<div class="tc"><a href='{{< relref "news/adult-intermediate-classes-fall-2026.md" >}}' class="btn raise">View Fall Intermediate & Int-Advanced schedules & tuition</a></div>
-
-### Advanced & Conversation {#advanced}
-
-Designed for students who can already hold conversations in Italian and want to refine their fluency, master advanced grammar structures, and discuss Italian literature, news, and culture in a collaborative setting.
-
-<div class="tc"><a href='{{< relref "news/adult-advanced-classes-fall-2026.md" >}}' class="btn raise">View Fall Advanced & Conversation schedule & tuition</a></div>
-
-## North County: Friday classes in Encinitas {#encinitas}
-
-New for Fall 2026: in-person Italian classes for adults in **Encinitas**, at San Dieguito United Methodist Church, [170 Calle Magdalena](https://maps.google.com/?q=170+Calle+Magdalena,+Encinitas,+CA+92024). A beginner and an intermediate section meet **Fridays, 6:00 PM - 7:30 PM**, September 18 to December 18, 2026 (13 classes). Tuition is $468 in full or four monthly payments of $128.70.
-
-<div class="tc"><a href='{{< relref "news/adult-italian-classes-encinitas-north-county-fall-2026.md" >}}' class="btn raise">View Encinitas Friday schedules & tuition</a></div>
-
-## Private & Custom Classes {#private-custom}
-
-### Private Lessons (In-person or via Zoom) {#private}
-
-One-on-one lessons tailored to your specific goals and pace. Enjoy flexible scheduling, custom curriculum design, and a 24-hour cancellation policy. All levels are welcome, from absolute beginner to advanced.
-
-<div class="tc"><a href='{{< relref "italian-private-classes.md" >}}' class="btn raise">Learn more about private lessons</a></div>
-
-### Italian On Demand (Flexible Online Private Lessons) {#on-demand}
-
-Need ultimate flexibility? Book virtual private lessons online via Zoom with as little as 12 hours' notice. Pay per session when it fits your schedule, without any long-term commitment. **Note: Italian On Demand is online only.**
-
-<div class="tc"><a href='{{< relref "italian-on-demand.md" >}}' class="btn raise">Learn more about Italian On Demand</a></div>
-
-### Italian for Businesses {#business}
-
-Custom language and cultural training for your team, delivered in person in San Diego or online via Zoom. We adapt our content to fit your specific industry needs.
-
-<div class="tc"><a href='{{< relref "italian-private-classes-business-san-diego.md" >}}' class="btn raise">Learn more about corporate Italian training</a></div>
-
-### Custom Group Classes {#custom-group}
-
-Interested in learning Italian with a group of friends, family members, or colleagues? We can set up custom group sessions online, at our facility, or at your preferred location. [Contact us!](/contact) to discuss details.
+  <article class="adult-option-card">
+    <p class="adult-card-kicker">Learn together</p>
+    <h3 id="custom-group">Custom group classes</h3>
+    <p>Create a program for friends, family, or colleagues, online, at our school, or at another location.</p>
+    <a href="/contact" class="adult-text-link">Discuss a custom class <span aria-hidden="true">→</span></a>
+  </article>
+</div>
 
 ## World languages for adults {#world-languages}
 
-Since 2021, Italian school of San Diego LLC has built a community around language and culture education. We are expanding our adult program beyond Italian to make small, structured, in-person language classes available to more San Diego learners while keeping the same focus on practical communication and community.
+<section class="adult-feature-callout adult-feature-callout-language" aria-labelledby="world-language-details">
+  <div>
+    <p class="adult-card-kicker">More ways to learn</p>
+    <h3 id="world-language-details">Beginner Spanish, German, and English</h3>
+    <p>Starting September 15, 2026, small in-person classes meet on Tuesdays from <strong>6:00–7:30 PM</strong>. The English class is designed for Spanish-speaking adults.</p>
+    <p>These programs bring our practical, community-centered approach to languages beyond Italian.</p>
+  </div>
+  <a href="/news/2026/08/world-language-classes-san-diego-fall-2026/" class="btn btn-cta">World language schedules</a>
+</section>
 
-Beginning September 15, 2026, we are offering in-person beginner Spanish, German, and English classes on Tuesdays from 6:00 PM to 7:30 PM. The English class is designed for Spanish-speaking adults.
+## Policies, discounts, and payment plans {#policies}
 
-<div class="tc"><a href='/news/2026/08/world-language-classes-san-diego-fall-2026/' class="btn raise">View world language schedules and enrollment</a></div>
+<div class="adult-policy-list">
+  <details>
+    <summary id="enrollment-confirmation">Enrollment and confirmation</summary>
+    <p>Classes are confirmed once they meet the minimum required enrollment. If a class is canceled due to low enrollment, we will offer to transfer you to another section or issue a full refund.</p>
+  </details>
+  <details>
+    <summary id="payment-plans">Payment plans</summary>
+    <p>We offer monthly payment plans consisting of <strong>5 payments</strong>. Plans include a 10% administrative fee and are not monthly enrollments. Enrollment commits you to all 5 payments for the full 15- or 16-class course.</p>
+  </details>
+  <details>
+    <summary id="cancellation">Cancellation and refunds</summary>
+    <ul>
+      <li>Full refund if you cancel at least 15 days before the first class.</li>
+      <li>50% refund if you cancel after the first class but before the second class.</li>
+      <li>No refunds after the start of the second class.</li>
+    </ul>
+    <p>To request a cancellation and refund, email <code>admin</code> at our <code>italianschoolsd.com</code> domain.</p>
+  </details>
+  <details>
+    <summary id="family-discount">Family discount</summary>
+    <p>Additional family members enrolling together receive a 10% discount, applied automatically at checkout.</p>
+  </details>
+</div>
 
----
+## Previous sessions {#previous-sessions}
 
-## Previous Sessions {#previous-sessions}
+<div class="adult-archive-links">
+  <a href='{{< relref "news/adult-beginner-classes-summer-2026.md" >}}'>Summer 2026</a>
+  <a href='{{< relref "news/adult-beginner-classes-january-may-2026.md" >}}'>January–May 2026</a>
+  <a href='{{< relref "news/italian-adult-classes-fall-2025.md" >}}'>Fall 2025</a>
+</div>
 
-- [Summer 2026]( {{< ref "news/adult-beginner-classes-summer-2026.md" >}} )
-- [January-May 2026]( {{< ref "news/adult-beginner-classes-january-may-2026.md" >}} )
-- [Fall 2025]( {{< ref "news/italian-adult-classes-fall-2025.md" >}} )
-
----
-
-## Policies, Discounts, and Payment Plans {#policies}
-
-### Enrollment & Confirmation {#enrollment-confirmation}
-
-Classes are confirmed once they meet the minimum required enrollment. If a class is canceled due to low enrollment, we will offer to transfer you to another section or issue a full refund.
-
-### Payment Plans (Installments) {#payment-plans}
-
-We offer monthly payment plans consisting of **5 payments** for adult classes. Monthly plans include a 10% administrative fee and are **not monthly enrollments**. If you enroll using a payment plan, you are committing to completing all 5 monthly payments for the full course (15 or 16 classes).
-
-### Cancellation & Refund Policy {#cancellation}
-
-- Full refund if you cancel at least 15 days before the first class.
-- 50% refund if you cancel after the first class but before the second class.
-- No refunds will be issued after the start of the second class.
-
-To request a cancellation and refund, please email `admin` at our domain `italianschoolsd.com`.
-
-### Family Discount {#family-discount}
-
-- 10% discount for all additional family members enrolling together (applied automatically at checkout).
+</div>

--- a/site/content/adults.md
+++ b/site/content/adults.md
@@ -13,18 +13,18 @@ subtitle: Italian classes in person across San Diego County and online via Zoom
   <h2 id="adult-welcome">Find the right class for your level and schedule</h2>
   <p>Choose from weekly group classes, flexible private lessons, and custom programs. All Italian classes are led by native Italian-speaking instructors.</p>
   <div class="adult-hero-actions">
-    <a href="#weekly-schedule" class="btn btn-cta">See the Fall schedule</a>
+    <a href='{{< relref "adults.md" >}}#weekly-schedule' class="btn btn-cta">See the Fall schedule</a>
     <a href="https://forms.gle/LHR7Htpeb3mQzV838" class="btn btn-cta">Tell us what you need</a>
   </div>
 </section>
 
 <nav class="adult-jump-links" aria-label="Adult classes page sections">
-  <a href="#fall-2026">Fall group classes</a>
-  <a href="#course-levels">Choose your level</a>
-  <a href="#encinitas">Encinitas classes</a>
-  <a href="#private-custom">Flexible options</a>
-  <a href="#world-languages">Other languages</a>
-  <a href="#policies">Policies and discounts</a>
+  <a href='{{< relref "adults.md" >}}#fall-2026'>Fall group classes</a>
+  <a href='{{< relref "adults.md" >}}#course-levels'>Choose your level</a>
+  <a href='{{< relref "adults.md" >}}#encinitas'>Encinitas classes</a>
+  <a href='{{< relref "adults.md" >}}#private-custom'>Flexible options</a>
+  <a href='{{< relref "adults.md" >}}#world-languages'>Other languages</a>
+  <a href='{{< relref "adults.md" >}}#policies'>Policies and discounts</a>
 </nav>
 
 <p class="adult-location-note"><strong>In-person classes:</strong> Most classes meet at our school at <a href='{{< relref "location.md" >}}'>4550 Kearny Villa Rd, Suite 202</a> in Kearny Mesa. Friday classes meet at our <a href='{{< relref "italian-classes-encinitas.md" >}}'>Encinitas location</a>.</p>


### PR DESCRIPTION
Closes ZON-206

## Summary

- replace the dense weekly table with responsive day-by-day schedule cards
- reorganize level, private, Encinitas, and policy content into scannable sections
- fix internal page navigation in Netlify previews
- refine level-card button spacing across responsive layouts
- add page-scoped responsive styling for desktop and mobile

## Verification

- `npm run build:hugo`
- inspected full-page desktop, tablet, and mobile screenshots
- click-tested every adult-page internal link on the Netlify preview
- verified level-card button geometry and all external destinations
