### PR TITLE
Name SoCal Scholars Academy alongside PCA everywhere charters appear

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -24,7 +24,7 @@ products2:
       link: /accredited-classes
     - image: /img/isola_bella.jpg
       title: "Italian Morning Program for Homeschoolers"
-      text: "Weekday morning Italian classes for homeschooled children and preschoolers, from age 3. Charter-funded through Pacific Coast Academy. Learning through play, songs, reading, and projects."
+      text: "Weekday morning Italian classes for homeschooled children and preschoolers, from age 3. Charter-funded through Pacific Coast Academy and SoCal Scholars Academy. Learning through play, songs, reading, and projects."
       link: /classes#home-schooled
     - image: /flyers/italianschoolsd-flyer-encinitas-2026-2027.png
       title: "Italian in Encinitas, North County"

--- a/site/content/classes.md
+++ b/site/content/classes.md
@@ -51,7 +51,7 @@ For 2026-2027, the Kearny Mesa morning program meets **Wednesdays, 10am-12pm** a
 * Session 1: **September 2, 2026-January 20, 2027**
 * Session 2: **January 27-May 19, 2027**
 
-The Italian School is a vendor for [Pacific Coast Academy](https://pacificcoastacademy.org/), so you can use charter funds to pay for our classes. If your child is enrolled in another charter, please contact us; we can apply to become vendors.
+The Italian School is an approved vendor for [Pacific Coast Academy](https://pacificcoastacademy.org/) and [SoCal Scholars Academy](https://socalscholarsacademy.net/), so you can use charter funds to pay for our classes, group or private. If your child is enrolled in another charter, please contact us; we can apply to become vendors.
 
 ## Italian for Spanish Speakers (TK-6) {#spanish-speakers}
 

--- a/site/content/italian-private-classes.md
+++ b/site/content/italian-private-classes.md
@@ -16,9 +16,9 @@ Whether you're a complete beginner or looking to polish your conversational skil
 
 ## Why Choose Private Lessons? {#why-private}
 
-- **All levels welcome** — absolute beginner, intermediate, or advanced. We meet you where you are.
-- **Flexible scheduling** — choose the day and time that works best for you, and reschedule when life gets in the way.
-- **In-person or online** — meet your teacher at our San Diego location ([4550 Kearny Villa Rd Suite 202]({{< ref "location.md" >}})), at your home, or connect from anywhere via Zoom.
+- **All levels welcome** — new beginner, intermediate, or advanced. We meet you where you are.
+- **Flexible scheduling** — choose the day and time that works best for you, and reschedule when life gets in the way. Daytime slots are available, which suits homeschool families.
+- **In-person or online** — meet your teacher at either of our two locations ([4550 Kearny Villa Rd Suite 202]({{< ref "location.md" >}}) in Kearny Mesa, or [San Dieguito United Methodist Church]({{< relref "italian-classes-encinitas.md" >}}) in Encinitas), at your home, or connect from anywhere via Zoom.
 - **Custom content** — preparing for a trip to Italy, studying for a certification, reconnecting with family heritage, or just learning for fun? We build the curriculum around you.
 - **Native Italian instructors** — every teacher on our staff is a native Italian speaker with hands-on experience teaching adults at all proficiency levels.
 
@@ -29,6 +29,14 @@ Whether you're a complete beginner or looking to polish your conversational skil
 1. **Fill out the interest form** — tell us about your goals, current level, and scheduling preferences.
 2. **We match you with a teacher** — based on your needs and availability, we pair you with the right instructor.
 3. **Start learning** — begin with a lesson plan designed just for you. Adjust the pace, topics, and focus at any time.
+
+---
+
+## Charter school families {#charter}
+
+Private lessons are on our approved list of services for both [Pacific Coast Academy](https://pacificcoastacademy.org/) and [SoCal Scholars Academy](https://socalscholarsacademy.net/), for TK through 12th grade, so charter funds can cover them: online, at either of our locations, or at your own home.
+
+Fill out the interest form, name your charter, and then submit an order through your charter's catalog. If your child attends a different charter, [contact us](/contact) and we can apply to become vendors.
 
 ---
 

--- a/site/content/news/italian-for-homeschoolers-2026-2027.md
+++ b/site/content/news/italian-for-homeschoolers-2026-2027.md
@@ -43,13 +43,39 @@ A second 16-class session will start the following week (**January 27, 2027**) a
 
 Italian school of San Diego in Kearny Mesa: [4550 Kearny Villa Rd Suite 202](https://goo.gl/maps/KqGhZAXJfkkLLsvYA)
 
-## Notice for Pacific Coast Academy families
+## Using charter funds {#charter}
 
-If you are enrolled in the Pacific Coast Academy homeschool program, please fill the pre-enrollment form and specify your program in the notes. Then, submit an order through the Pacific Coast Academy catalog. We will confirm your enrollment upon receiving the order from Pacific Coast Academy.
+We are an approved vendor for the 2026-2027 school year with both:
 
-## Private Italian classes
+* [Pacific Coast Academy](https://pacificcoastacademy.org/)
+* [SoCal Scholars Academy](https://socalscholarsacademy.net/)
 
-We also offer private Italian classes online or in-person, tailored to your level and interests. Please [contact us]({{< relref "contact.md" >}}) for more information.
+Both our group classes and our private lessons are on our approved list of services, so charter funds can cover either.
+
+If you are enrolled with one of them, fill the pre-enrollment form above and name your charter in the notes, then submit an order through your charter's catalog. We confirm your enrollment when the order reaches us.
+
+If your child attends a different charter, [contact us]({{< relref "contact.md" >}}). We can apply to become vendors.
+
+## Come meet us first {#info-nights}
+
+Before you decide, come to one of our two free info nights. One hour, no obligation, and the Kearny Mesa evening covers this morning program:
+
+* **Kearny Mesa:** Thursday, August 13, 2026, 6:00-7:00 PM, 4550 Kearny Villa Rd, Suite 202
+* **Encinitas:** Tuesday, August 25, 2026, 6:00-7:00 PM, San Dieguito United Methodist Church
+
+Please RSVP so we know how many chairs to set out, on Facebook or by emailing [info@italianschoolsd.com](mailto:info@italianschoolsd.com).
+
+<div class="tc">
+<a href='{{< relref "news/free-info-nights-kids-italian-classes-2026-2027.md" >}}' class="btn raise">Both info nights: addresses, parking, and how to RSVP</a>
+</div>
+
+## Other ways to learn Italian with us {#other-options}
+
+The Wednesday morning program is not the only option for a homeschool family, and charter funds apply to these too:
+
+* **Wednesday afternoons, 4:00-6:00 PM** in Kearny Mesa, TK-6th grade, from August 26. See [Italian classes for kids]({{< relref "classes.md" >}}).
+* **Monday afternoons, 4:00-6:00 PM** in Encinitas, TK-5th grade, from September 14. See [Italian classes in Encinitas]({{< relref "italian-classes-encinitas.md" >}}).
+* **Private lessons**, at either of our two locations, at your own home, or online. See [private Italian lessons]({{< relref "italian-private-classes.md" >}}).
 
 ## Please share with friends
 

--- a/site/content/news/late-enrollment-kids-italian-classes-2026-2027.md
+++ b/site/content/news/late-enrollment-kids-italian-classes-2026-2027.md
@@ -41,7 +41,7 @@ Tuition covers **33 weeks of instruction**, from August through May:
 
 An **8-payment plan** and a **sibling discount** are available. See [payment details and cancellation policy](/tuition-payment).
 
-The morning homeschool program is priced per 16-class session. We are a vendor for [Pacific Coast Academy](https://pacificcoastacademy.org/), so charter funds can be used for our classes. If your child attends another charter, [contact us](/contact) and we can apply to become vendors.
+The morning homeschool program is priced per 16-class session. We are an approved vendor for [Pacific Coast Academy](https://pacificcoastacademy.org/) and [SoCal Scholars Academy](https://socalscholarsacademy.net/), so charter funds can be used for our classes. If your child attends another charter, [contact us](/contact) and we can apply to become vendors.
 
 ## How to enroll {#enroll}
 


### PR DESCRIPTION
We have been an approved vendor for **SoCal Scholars Academy** since the 25/26 agreement, and the 26-27 Dehesa School District vendor agreement completed on July 10, 2026. The site never said so. Every charter sentence named Pacific Coast Academy only, so a SoCal Scholars family reading our homeschool page had no reason to believe their funds worked here.

This adds SoCal Scholars Academy everywhere Pacific Coast Academy already appeared, and fixes three gaps those sentences left.

## SoCal Scholars Academy named alongside PCA

| Page | What it said |
| --- | --- |
| `_index.md` | homeschool card: "Charter-funded through Pacific Coast Academy" |
| `classes.md` | "The Italian School is a vendor for Pacific Coast Academy" |
| `news/italian-for-homeschoolers-2026-2027.md` | a section titled "Notice for Pacific Coast Academy families" |
| `news/late-enrollment-kids-italian-classes-2026-2027.md` | "We are a vendor for Pacific Coast Academy" |

Links go to `pacificcoastacademy.org` and `socalscholarsacademy.net`, both checked (200).

## Private lessons are fundable, and never said so

Private lessons are on the approved services list for both charters at $75-$120/hr depending on location, TK-12. Nothing on the site connected private lessons to charter funds at all. `italian-private-classes.md` gets a **Charter school families** section.

That page also only ever named Kearny Mesa as an in-person option, three months after Encinitas opened. It now names both, and says daytime slots exist, which is the detail a homeschool family is looking for.

## The homeschool page now points at the info nights

The Kearny Mesa info night on **August 13** explicitly covers the morning program, and the homeschool page had no route to it. It does now, with both evenings, times, addresses and the RSVP ask.

This matters beyond tidiness: `/homeschool` is the landing page for the new homeschool video ad, and that ad promises both info nights on screen.

## The homeschool page now admits there are other options

The Wednesday 10am program was presented as the only thing a homeschool family could do with us. Added, with their own start dates, and noting funds apply to all of them:

- Wednesday afternoons 4-6pm, Kearny Mesa, TK-6th, from Aug 26
- Monday afternoons 4-6pm, Encinitas, TK-5th, from Sep 14
- Private lessons at either location, at home, or online

## Also

`italian-private-classes.md` said "absolute beginner", which is phrasing we do not use. Changed to "new beginner".

## Checks

`npm run build:hugo` clean, 257 pages. Every new `relref` resolves: `/contact/`, `/classes/`, `/italian-classes-encinitas/`, `/italian-private-classes/`, `/news/2026/08/free-info-nights-kids-italian-classes-2026-2027/`.

Content only, no layout or style changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
